### PR TITLE
Allow specifying individual headers for Graphs, Records, Reports, About pages

### DIFF
--- a/skins/Belchertown/page-header.inc
+++ b/skins/Belchertown/page-header.inc
@@ -6,7 +6,17 @@
         </div>
         <div class="col-sm-5">
             <div class="wx-stn-name">
+		#if $page == "graphs"
+                <h1>$Extras.graphs_page_header</h1>
+		#else if $page == "records"
+                <h1>$Extras.records_page_header</h1>
+		#else if $page == "reports"
+                <h1>$Extras.reports_page_header</h1>
+		#else if $page == "records"
+                <h1>$Extras.records_page_header</h1>
+		#else if $page == "about"
                 <h1>$Extras.about_page_header</h1>
+		#end if
             </div>
         </div>
         <div class="col-sm-5" style="float:right;">


### PR DESCRIPTION
This update enables entering the values of the tags

> graphs_page_header
> reports_page_header
> records_page_header
> about_page_header

into the headers of the corresponding pages