### PR TITLE
belchertown.py: Use floats for the charts JSON

### DIFF
--- a/skins/Belchertown/graphs.conf.example
+++ b/skins/Belchertown/graphs.conf.example
@@ -81,7 +81,7 @@ tooltip_date_format = "LLL"
         type = spline
         [[[barometer]]]
             color = "#BECC00"
-            yAxis_tickInterval = 0.01
+            yaxis_tickinterval = 0.01
             
 [day]
     # Chart Timespan Defaults


### PR DESCRIPTION
This PR contains the changes discussed in #185. It changes the conversion from integer to floats and also includes a small fix for the capitalization in `graphs.conf.example`.