### PR TITLE
Re-connect websocket for PWA mode on iOS.

### DIFF
--- a/skins/Belchertown/header.html.tmpl
+++ b/skins/Belchertown/header.html.tmpl
@@ -97,7 +97,7 @@
         <script type='text/javascript' src="//ajax.googleapis.com/ajax/libs/jqueryui/1.12.1/jquery-ui.min.js"></script>
         <script type='text/javascript' src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment-with-locales.min.js"></script>
         #if $page == "home" and $Extras.has_key("mqtt_websockets_enabled") and $Extras.mqtt_websockets_enabled == '1'
-        <script type='text/javascript' src="//cdnjs.cloudflare.com/ajax/libs/paho-mqtt/1.0.1/mqttws31.min.js"></script>
+        <script type='text/javascript' src="//cdnjs.cloudflare.com/ajax/libs/paho-mqtt/1.1.0/paho-mqtt.min.js"></script>
         #end if
         <script type='text/javascript' src='//code.highcharts.com/stock/7.1.2/highstock.js'></script>
         <script type='text/javascript' src='//code.highcharts.com/7.1.2/highcharts-more.js'></script>

--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -719,7 +719,7 @@ function connect() {
     jQuery(".offlineMarker").hide();
     jQuery(".loadingMarker").show();
     
-    client = new Paho.MQTT.Client("$Extras.mqtt_websockets_host", $Extras.mqtt_websockets_port, mqttclient);
+    client = new Paho.Client("$Extras.mqtt_websockets_host", $Extras.mqtt_websockets_port, mqttclient);
     client.onConnectionLost = onConnectionLost;
     client.onMessageArrived = onMessageArrived;
     var options = {
@@ -728,6 +728,7 @@ function connect() {
         #else
         useSSL: false,
         #end if
+        reconnect: true,
         onSuccess:onConnect,
         onFailure:onFailure
       }


### PR DESCRIPTION
* Update `paho-mqtt` to use `reconnected` option for `connect()` call.

Tested on Chrome & iOS 13.x - working for me.
