### PR TITLE
Changed width of iPad forecast to fit on one line

### DIFF
--- a/skins/Belchertown/style.css
+++ b/skins/Belchertown/style.css
@@ -902,7 +902,7 @@ p.entry-meta {
     }
     
     .forecasts .forecast-day {
-        width: 235px;
+        width: 165px;
     }
     
     .eq-stats-row .col-sm-9 {


### PR DESCRIPTION
Changed the width of the forecast area on iPad to match the width of the forecast area on desktop, so it displays on one line