### PR TITLE
User can pass color and yAxis_softMax as options

### DIFF
--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -1904,11 +1904,6 @@ function showChart(json_file, prepend_renderTo=false) {
                 options.plotOptions = {
                     turboThreshold: 0,
                     series: {
-         //               states: {
-         //                   hover: {
-         //                       enabled: false 
-         //                   }
-         //               },
                         marker: {
                             enabled: false
                         }
@@ -1929,7 +1924,7 @@ function showChart(json_file, prepend_renderTo=false) {
                     tickInterval: 2,
                     tickmarkPlacement: 'on',
                     min: -1,
-                    softMax: 15,
+                    softMax: options.series[0].yAxis_softMax,
                     title: {
                         text: options.series[0].yAxis_label,
                     },
@@ -1950,7 +1945,7 @@ function showChart(json_file, prepend_renderTo=false) {
                             var rounding = point.series.userOptions.rounding;
                             var mirrored = point.series.userOptions.mirrored_value;
                             var numberFormat = point.series.userOptions.numberFormat ? point.series.userOptions.numberFormat : "";
-                            return "<strong>" + moment.unix( point.x / 1000).utcOffset($moment_js_utc_offset).format( tooltip_date_format ) + "</strong><br><span style='color:" + color + "'>\u25CF</span> $obs.label.highest_temperature: " + highcharts_tooltip_factory( point.point.high, observation_type, true, rounding, mirrored, numberFormat ) + "<br><span style='color:" + color + "'>\u25CF</span> $obs.label.lowest_temperature: " + highcharts_tooltip_factory( point.point.low, observation_type, true, rounding, mirrored, numberFormat );
+                            return "<strong>" + moment.unix( point.x / 1000).utcOffset($moment_js_utc_offset).format( tooltip_date_format ) + "</strong><br><span style='color:" + options.series[0].color + "'>\u25CF</span> $obs.label.highest_temperature: " + highcharts_tooltip_factory( point.point.high, observation_type, true, rounding, mirrored, numberFormat ) + "<br><span style='color:" + options.series[0].color + "'>\u25CF</span> $obs.label.lowest_temperature: " + highcharts_tooltip_factory( point.point.low, observation_type, true, rounding, mirrored, numberFormat );
                         });
                     }
                 }
@@ -1959,7 +1954,7 @@ function showChart(json_file, prepend_renderTo=false) {
                 var currentSeriesData = options.series[0].data;
                 var range_unit = options.series[0].range_unit;
                 var newSeriesData = [];
-                var color = "#ff4500";
+                var currentSeriesColor = options.series[0].color;
                 currentSeriesData.forEach( seriesData => {
                     // If a data point is from the future, max/min are set to null. For some reason Highcharts draws a glitchy connection between the end and beginning of the data set on the radial graph (i.e. when the day is only half over and the graph only half filled), even if connectEnds is turned off. Until that's fixed, set null values to 0 so the chart renders cleanly all the way through 360 degrees 
                     if ( seriesData[1] == null ) {
@@ -1977,8 +1972,8 @@ function showChart(json_file, prepend_renderTo=false) {
                     data: newSeriesData,
                     obsType: "haysChart",
                     obsUnit: range_unit,
-                    color: color,
-                    fillColor: color,
+                    color: currentSeriesColor,
+                    fillColor: currentSeriesColor,
                 });
             }
 


### PR DESCRIPTION
Added the option to specify chart color and yAxis_softMax as options in chart.conf. Below are the settings I use to get an approximation of a typical Hays chart:

```
[[exampleChart]]
    title = Wind Speed Today
    time_length = today
    [[[haysChart]]]
        color = "#ff4500"
        yAxis_softMax = 25
```