### PR TITLE
Added support for GeoNet (NZ) earthquake server

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ For ease of readability I have broken them out into separate tables. However you
 | earthquake_enabled | 0 | 1 = enable, 0 = disable. Show the earthquake data on the front page
 | earthquake_maxradiuskm | 1000 | The radius in kilometers from your weewx.conf's latitude and longitude to search for the most recent earthquake.
 | earthquake_stale | 10740 | The number of seconds after which the skin will download new earthquake data from USGS. Recommended setting is every 3 hours to be kind to the USGS servers. 10800 seconds = 3 hours. 10740 = 2 hours 59 minutes
+| earthquake_server | USGS | USGS for USGS website (best for North American Users) or GeoNet for NZ GeoNet website (best for NZ users)
 
 ### Social Options
 

--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -647,7 +647,10 @@ class getData(SearchList):
             longitude = self.generator.config_dict['Station']['longitude']
             earthquake_maxradiuskm = self.generator.skin_dict['Extras']['earthquake_maxradiuskm']
             #Sample URL from Belchertown Weather: http://earthquake.usgs.gov/fdsnws/event/1/query?limit=1&lat=42.223&lon=-72.374&maxradiuskm=1000&format=geojson&nodata=204&minmag=2
-            earthquake_url = "http://earthquake.usgs.gov/fdsnws/event/1/query?limit=1&lat=%s&lon=%s&maxradiuskm=%s&format=geojson&nodata=204&minmag=2" % ( latitude, longitude, earthquake_maxradiuskm )
+            if self.generator.skin_dict['Extras']['earthquake_server'] == "USGS":
+                earthquake_url = "http://earthquake.usgs.gov/fdsnws/event/1/query?limit=1&lat=%s&lon=%s&maxradiuskm=%s&format=geojson&nodata=204&minmag=2" % ( latitude, longitude, earthquake_maxradiuskm )
+            elif self.generator.skin_dict['Extras']['earthquake_server'] = "GeoNet":
+                earthquake_url = "https://api.geonet.org.nz/quake?MMI=4"
             earthquake_is_stale = False
             
             # Determine if the file exists and get it's modified time
@@ -707,10 +710,17 @@ class getData(SearchList):
                     eqdata = ""
             
             try:
-                eqtime = eqdata["features"][0]["properties"]["time"] / 1000
-                equrl = eqdata["features"][0]["properties"]["url"]
-                eqplace = eqdata["features"][0]["properties"]["place"]
-                eqmag = eqdata["features"][0]["properties"]["mag"]
+                if self.generator.skin_dict['Extras']['earthquake_server'] = "USGS":
+                    eqtime = eqdata["features"][0]["properties"]["time"] / 1000
+                    equrl = eqdata["features"][0]["properties"]["url"]
+                    eqplace = eqdata["features"][0]["properties"]["place"]
+                    eqmag = eqdata["features"][0]["properties"]["mag"]
+                elif self.generator.skin_dict['Extras']['earthquake_server'] = "GeoNet":
+                    eqtime = eqdata["features"][0]["properties"]["time"]
+                    equrl = ("https://www.geonet.org.nz/earthquake/" +
+                            eqdata["features"][0]["properties"]["publicID"])
+                    eqplace = eqdata["features"][0]["properties"]["locality"]
+                    eqmag = round(eqdata["features"][0]["properties"]["magnitude"],1)
                 eqlat = str( round( eqdata["features"][0]["geometry"]["coordinates"][0], 4 ) )
                 eqlon = str( round( eqdata["features"][0]["geometry"]["coordinates"][1], 4 ) )
             except:

--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -717,6 +717,10 @@ class getData(SearchList):
                     eqmag = eqdata["features"][0]["properties"]["mag"]
                 elif self.generator.skin_dict['Extras']['earthquake_server'] = "GeoNet":
                     eqtime = eqdata["features"][0]["properties"]["time"]
+                    #convert time to UNIX format
+                    eqtime = eqtime.replace("Z","")
+                    eqtime = datetime.datetime.fromisoformat(eqtime)
+                    eqtime = int(eqtime.replace(tzinfo=datetime.timezone.utc).timestamp())
                     equrl = ("https://www.geonet.org.nz/earthquake/" +
                             eqdata["features"][0]["properties"]["publicID"])
                     eqplace = eqdata["features"][0]["properties"]["locality"]

--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -649,7 +649,7 @@ class getData(SearchList):
             #Sample URL from Belchertown Weather: http://earthquake.usgs.gov/fdsnws/event/1/query?limit=1&lat=42.223&lon=-72.374&maxradiuskm=1000&format=geojson&nodata=204&minmag=2
             if self.generator.skin_dict['Extras']['earthquake_server'] == "USGS":
                 earthquake_url = "http://earthquake.usgs.gov/fdsnws/event/1/query?limit=1&lat=%s&lon=%s&maxradiuskm=%s&format=geojson&nodata=204&minmag=2" % ( latitude, longitude, earthquake_maxradiuskm )
-            elif self.generator.skin_dict['Extras']['earthquake_server'] = "GeoNet":
+            elif self.generator.skin_dict['Extras']['earthquake_server'] == "GeoNet":
                 earthquake_url = "https://api.geonet.org.nz/quake?MMI=4"
             earthquake_is_stale = False
             
@@ -710,12 +710,12 @@ class getData(SearchList):
                     eqdata = ""
             
             try:
-                if self.generator.skin_dict['Extras']['earthquake_server'] = "USGS":
+                if self.generator.skin_dict['Extras']['earthquake_server'] == "USGS":
                     eqtime = eqdata["features"][0]["properties"]["time"] / 1000
                     equrl = eqdata["features"][0]["properties"]["url"]
                     eqplace = eqdata["features"][0]["properties"]["place"]
                     eqmag = eqdata["features"][0]["properties"]["mag"]
-                elif self.generator.skin_dict['Extras']['earthquake_server'] = "GeoNet":
+                elif self.generator.skin_dict['Extras']['earthquake_server'] == "GeoNet":
                     eqtime = eqdata["features"][0]["properties"]["time"]
                     #convert time to UNIX format
                     eqtime = eqtime.replace("Z","")

--- a/skins/Belchertown/skin.conf
+++ b/skins/Belchertown/skin.conf
@@ -75,6 +75,7 @@
     earthquake_enabled = 0
     earthquake_maxradiuskm = 1000
     earthquake_stale = 10740
+    earthquake_server = USGS
 
     # Social Share Button Defaults. Define the text below under Labels
     facebook_enabled = 0


### PR DESCRIPTION
Hi there,

I recently enabled the earthquake option and quickly realised that the earthquake resolution is not ideal for me (based in NZ). I subsequently discovered that our local earthquake service (GeoNet) has an API with similar format to the USGS API. Consequently, I modified the code in your skin to include support for the GeoNet server in NZ. I had to make a few changes to handle the different API response, and I also added a new option to the skin called "earthquake_server" with default "USGS" or alternatively "GeoNet" (I modified the markdown intro to show this option also). 

Hopefully the change would be relatively painless and your US users would not notice any difference.

Hope you can review the code, and if you like it incorporate it within your main branch. Happy also to take any constructive feedback.

Note, I've tested this and it is running live at my site: [https://mpyc.nz/weather](https://mpyc.nz/weather)

Cheers,
Brad.