### PR TITLE
Add configuration options for radar marker and zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ For ease of readability I have broken them out into separate tables. However you
 | manifest_name | "My Weather Website" | Progressive Webapp: This is the name of your site when adding it as an app to your mobile device.
 | manifest_short_name | "MWW" | Progressive Webapp: This is the name of the icon on your mobile device for your website's app.
 | radar_html | A windy.com iFrame | Full HTML Allowed. Recommended size 650 pixels wide by 360 pixels high. This URL will be used as the radar iFrame or image hyperlink. If you are using windy.com for live radar, they have instructions on how to embed their maps. Go to windy.com, click on Weather Radar on the right, then click on embed widget on page. Make sure you use the sizes recommended earier in this description.
+| radar_zoom | 8 | Initial zoom level for radar. 11 = highest zoom, 1 = lowest zoom.
+| radar_marker | 0 | Shows a marker on the radar indicating the position of the weather station. 1 = enable, 0 = disable.
 | almanac_extras | 1 | Show the extra almanac details if available. **Requires pyephem to be installed on your machine.** Refer to the weewx user guide on more information.
 | highcharts_enabled | 1 | Show the charts on the website. 1 = enable, 0 = disable.
 | graph_page_show_all_button | 1 | Setting to 1 will enable an "All" button which will allow visitors to see all your graphs on one page in a condensed format with 2 graphs on a row (like the home page).

--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -248,7 +248,15 @@ class getData(SearchList):
         if self.generator.skin_dict['Extras']['radar_html'] == "":
             lat = self.generator.config_dict['Station']['latitude']
             lon = self.generator.config_dict['Station']['longitude']
-            radar_html = '<iframe width="650" height="360" src="https://embed.windy.com/embed2.html?lat={}&lon={}&zoom=8&level=surface&overlay=radar&menu=&message=true&marker=&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat={}&detailLon={}&metricWind=&metricTemp=&radarRange=-1" frameborder="0"></iframe>'.format( lat, lon, lat, lon )
+            if 'radar_zoom' in self.generator.skin_dict['Extras']:
+                zoom = self.generator.skin_dict['Extras']['radar_zoom']
+            else:
+                zoom = "8"
+            if 'radar_marker' in self.generator.skin_dict['Extras'] and self.generator.skin_dict['Extras']['radar_marker'] == "1":
+                marker = "true"
+            else:
+                marker = ""
+            radar_html = '<iframe width="650" height="360" src="https://embed.windy.com/embed2.html?lat={}&lon={}&zoom={}&level=surface&overlay=radar&menu=&message=true&marker={}&calendar=&pressure=&type=map&location=coordinates&detail=&detailLat={}&detailLon={}&metricWind=&metricTemp=&radarRange=-1" frameborder="0"></iframe>'.format( lat, lon, zoom, marker, lat, lon )
         else:
             radar_html = self.generator.skin_dict['Extras']['radar_html']
         


### PR DESCRIPTION
The default "marker" in the Windy radar is the viewer's geolocated position.
Allow for adding another optional marker that indicates the weather station's position.
Also allow for adjusting the initial zoom level.