### PR TITLE
Implement Highcharts fix for Hays chart

### DIFF
--- a/skins/Belchertown/header.html.tmpl
+++ b/skins/Belchertown/header.html.tmpl
@@ -102,8 +102,8 @@
         #if $page == "pi" or $page == "home" and $Extras.has_key("mqtt_websockets_enabled") and $Extras.mqtt_websockets_enabled == '1'
         <script type='text/javascript' src="//cdnjs.cloudflare.com/ajax/libs/paho-mqtt/1.1.0/paho-mqtt.min.js"></script>
         #end if
-        <script type='text/javascript' src='//code.highcharts.com/stock/8.1/highstock.js'></script>
-        <script type='text/javascript' src='//code.highcharts.com/8.1/highcharts-more.js'></script>
+        <script type='text/javascript' src='//code.highcharts.com/stock/highstock.js'></script>
+        <script type='text/javascript' src='//code.highcharts.com/highcharts-more.js'></script>
         <script type='text/javascript' src='//code.highcharts.com/modules/exporting.js'></script>
         <script type='text/javascript' src='//stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js'></script>
         <script type='text/javascript' src='$relative_url/js/belchertown.js?#echo int( time.time() )#'></script>

--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -1963,11 +1963,6 @@ function showChart(json_file, prepend_renderTo=false) {
                 var newSeriesData = [];
                 var currentSeriesColor = options.series[0].color;
                 currentSeriesData.forEach( seriesData => {
-                    // If a data point is from the future, max/min are set to null. For some reason Highcharts draws a glitchy connection between the end and beginning of the data set on the radial graph (i.e. when the day is only half over and the graph only half filled), even if connectEnds is turned off. Until that's fixed, set null values to 0 so the chart renders cleanly all the way through 360 degrees 
-                    if ( seriesData[1] == null ) {
-                        seriesData[1] = 0;
-                        seriesData[2] = 0;
-                    };
                     newSeriesData.push({
                         x: seriesData[0],
                         low: seriesData[1],
@@ -1981,6 +1976,7 @@ function showChart(json_file, prepend_renderTo=false) {
                     obsUnit: range_unit,
                     color: currentSeriesColor,
                     fillColor: currentSeriesColor,
+                    connectEnds: false,
                 });
             }
 


### PR DESCRIPTION
Previous Highcharts versions had a bug that caused rendering errors in the Hays chart whenever it wasn’t completely filled in (i.e. halfway through the day). As a temporary workaround, all “future” values on the chart had to be explicitly set to 0 instead of null. Highcharts has fixed the bug on their latest stable release, so that workaround is no longer necessary (and the charts look much cleaner). 