### PR TITLE
chrome throwing console errors fetching manifest.json when site requires authorization

### DIFF
--- a/skins/Belchertown/header.html.tmpl
+++ b/skins/Belchertown/header.html.tmpl
@@ -84,7 +84,7 @@
         <link rel='stylesheet' href='$relative_url/custom.css?ver=#echo int( time.time() ) #' type='text/css' media='all' id="belchertownCustomStyle" />
         #end if
         
-        <link rel="manifest" href="$relative_url/manifest.json">
+        <link rel="manifest" href="$relative_url/manifest.json" crossorigin="use-credentials">
         <link rel="apple-touch-icon" href="$relative_url/images/station.png">
         <link rel="apple-touch-icon" sizes="48x48" href="$relative_url/images/station48.png">
         <link rel="apple-touch-icon" sizes="72x72" href="$relative_url/images/station72.png">


### PR DESCRIPTION
First off, thanks for this wonderful skin and for doing the work to get fast updates via MQTT; finally I can ride out wunderground outages with accurate wind info!  Big thanks for sharing.  In that spirit I want to share back a teensy tweak.

This is only relevant if one has protected pages of a weather site, so you may not care, and of course would need to confirm this is otherwise harmless.

Even though manifest.json was accessible as a link
per https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin
"The use-credentials value must be used when fetching a manifest that requires credentials,
even if the file is from the same origin."
So we fix that with crossorigin flag