### PR TITLE
Fix custom (plural) unit labels

### DIFF
--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -1272,9 +1272,9 @@ class getData(SearchList):
             if obs not in all_obs_rounding_json:
                 all_obs_rounding_json[obs] = str(obs_round)
             # Get the unit's label
-                obs_unit_label = self.generator.skin_dict['Units']['Labels'].get(obs_unit, "")
             # Add to label array and strip whitespace if possible
             if obs not in all_obs_unit_labels_json:
+                obs_unit_label = weewx.units.get_label_string(self.generator.formatter, self.generator.converter, obs)                
                 all_obs_unit_labels_json[obs] = obs_unit_label
             
             # Special handling items


### PR DESCRIPTION
Moved and changed the relevant code.

Using get_label_string solved this issue for me. This function defaults to plural, but that has been applied in the same way here:

https://github.com/poblabs/weewx-belchertown/blob/7537da3c796e6ef7e4c331ff9a04ec1804418d2d/bin/user/belchertown.py#L1741

The remark about "strip whitespace" in the comment was not clear to me, so I left it as it is:
            # Add to label array and strip whitespace if possible

Maybe it needs some extra error checking?