### PR TITLE
Fix to apply (default) locale day and month names to x-axis using mom…

### DIFF
--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -1597,6 +1597,10 @@ Highcharts.setOptions({
         timezoneOffset: $highcharts_timezoneoffset
     },
     lang: {
+        months: moment.months(),
+        shortMonths: moment.monthsShort(),
+        weekdays: moment.weekdays(),
+        shortWeekdays: moment.weekdaysShort(),
         decimalPoint: "$highcharts_decimal",
         thousandsSep: "$highcharts_thousands"
     }


### PR DESCRIPTION
…ent.js as provider

As mentioned in this issue #416