### PR TITLE
Responsive windrow error - correction for #444

### DIFF
--- a/skins/Belchertown/index.html.tmpl
+++ b/skins/Belchertown/index.html.tmpl
@@ -215,57 +215,61 @@
                         </div>
                         
                         <!-- Wind -->
+                        <div class="obs-wind-divider"></div>
                         <div class="row windrow">
                             <div class="weather-obs-bottom">
-                            <div class="col-sm-12 current_wind">
-                                <div class="col-sm-6">
-                                    <div class="compass">
-                                        <div class="direction">
-                                            <span class="curwinddir">
-                                            #if $current.windDir.ordinal_compass == "N/A"
-                                            --
-                                            #else
-                                            $current.windDir.ordinal_compass
-                                            #end if
-                                            </span>
-                                            <span class="curwinddeg">
-                                            #if $current.windDir.raw is None:
-                                            -
-                                            #else
-                                            $current.windDir.format("%.0f")
-                                            #end if
-                                            </span>
+                                <div class="col-sm-12 current_wind">
+                                    <div class="col-sm-6">
+                                        <div class="compass">
+                                            <div class="direction">
+                                                <span class="curwinddir">
+                                                #if $current.windDir.ordinal_compass == "N/A"
+                                                --
+                                                #else
+                                                $current.windDir.ordinal_compass
+                                                #end if
+                                                </span>
+                                                <span class="curwinddeg">
+                                                #if $current.windDir.raw is None:
+                                                -
+                                                #else
+                                                $current.windDir.format("%.0f")
+                                                #end if
+                                                </span>
+                                            </div>
+                                            <div class="arrow"></div>
                                         </div>
-                                        <div class="arrow"></div>
+                                                                 
+                                    </div>
+                                      
+                                    <div class="col-sm-6 windspeedtable">
+                                        <table class="wind-table">
+                                            <tbody>
+                                                <tr>
+                                                    <td class="windtext">$obs.label.wind_speed</td>
+                                                    <td class="windtext border-left gust">$obs.label.wind_gust</td>
+                                                </tr>
+                                                <tr>
+                                                    <td>
+                                                        <span class="curwindspeed">
+                                                            $current.windSpeed.toString(addLabel=False, NONE_string="--")
+                                                        </span>
+                                                    </td>
+                                                    <td class="border-left gust">&nbsp;
+                                                        <span class="curwindgust">
+                                                            $current.windGust.toString(addLabel=False, NONE_string="--")
+                                                        </span>
+                                                    </td>
+                                                </tr>
+                                                <tr>
+                                                    <td class="mph" colspan="3">$unit.label.windSpeed</td>
+                                                </tr>
+                                            </tbody>
+                                        </table>
                                     </div>
                                 </div>
-                                <div class="col-sm-6 windspeedtable">
-                                    <table class="wind-table">
-                                        <tbody>
-                                            <tr>
-                                                <td class="windtext">$obs.label.wind_speed</td>
-                                                <td class="windtext border-left gust">$obs.label.wind_gust</td>
-                                            </tr>
-                                            <tr>
-                                                <td>
-                                                    <span class="curwindspeed">
-                                                        $current.windSpeed.toString(addLabel=False, NONE_string="--")
-                                                    </span>
-                                                </td>
-                                                <td class="border-left gust">&nbsp;
-                                                    <span class="curwindgust">
-                                                        $current.windGust.toString(addLabel=False, NONE_string="--")
-                                                    </span>
-                                                </td>
-                                            </tr>
-                                            <tr>
-                                                <td class="mph" colspan="3">$unit.label.windSpeed</td>
-                                            </tr>
-                                        </tbody>
-                                    </table>
-                                </div>
                             </div>
-                            </div>
+                                  
                         </div>
                     </div>
                     

--- a/skins/Belchertown/style.css
+++ b/skins/Belchertown/style.css
@@ -860,6 +860,10 @@ p.entry-meta {
 		width: 400px;
 	}
 
+    .obs-wind-divider {
+        display: none;    
+    }
+
 }
 
 /* iPad Landscape */
@@ -1484,15 +1488,21 @@ p.entry-meta {
     width:50%;
 }
 
+.obs-wind-divider {
+    height: 1px;
+    width: 105%;
+    background-color: #D7D7D7;   
+}
+
 .windrow {
-    /* margin-top: 25px; */
-    box-sizing: border-box;
-    border-top: 1px solid #D7D7D7;
-    padding-top: 10px;
-    padding-right: 15px;
-    /* margin: 0 -15px 0 -15px; */
-    margin: 0 0 0 0;
-    width: 385px;
+	/* margin-top: 25px; */
+	/* box-sizing: border-box; */
+	border-top: 1px solid #D7D7D7;
+	padding-top: 10px;
+	/* padding-right: 15px; */
+	/* margin: 0 -15px 0 -15px; */
+	margin: -1px  0 0 0;
+	/* width: 105%;	*/	
 }
 
 .curwind {


### PR DESCRIPTION
This is a correction to PR #444 that was merged into the Belchertown master.
It restores responsive mode to the wind display whilst retaining the horizontal alignment of temperature and wind measurements.
My thanks to @fvirgola80 for spotting it.
Michael