### PR TITLE
Aeris AQI and AQI chart option

### DIFF
--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -87,6 +87,10 @@ except ImportError:
 VERSION = "1.2"
 loginf("version %s" % VERSION)
 
+aqi = 0
+aqi_category = ""
+aqi_time = 0
+
 class getData(SearchList):
     def __init__(self, generator):
         SearchList.__init__(self, generator)
@@ -200,6 +204,11 @@ class getData(SearchList):
         """
         Build the data needed for the Belchertown skin
         """
+
+        global aqi
+        global aqi_category
+        global aqi_time
+
         
         # Look for the debug flag which can be used to show more logging
         weewx.debug = int(self.generator.config_dict.get('debug', 0))
@@ -891,6 +900,7 @@ class getData(SearchList):
                 else:
                     forecast_current_url = "https://api.aerisapi.com/observations/%s,%s?&format=json&filter=allstations&limit=1&client_id=%s&client_secret=%s" % ( latitude, longitude, forecast_api_id, forecast_api_secret )
                 forecast_url = "https://api.aerisapi.com/forecasts/%s,%s?&format=json&filter=day&limit=7&client_id=%s&client_secret=%s" % ( latitude, longitude, forecast_api_id, forecast_api_secret )
+                aqi_url = "https://api.aerisapi.com/airquality/closest?p=%s,%s&format=json&radius=25mi&limit=10&client_id=%s&client_secret=%s" % ( latitude, longitude, forecast_api_id, forecast_api_secret )
                 if self.generator.skin_dict['Extras']['forecast_alert_limit']:
                     forecast_alert_limit = self.generator.skin_dict['Extras']['forecast_alert_limit']
                     forecast_alerts_url = "https://api.aerisapi.com/alerts/%s,%s?&format=json&limit=%s&lang=%s&client_id=%s&client_secret=%s" % ( latitude, longitude, forecast_alert_limit, forecast_lang, forecast_api_id, forecast_api_secret )
@@ -938,6 +948,11 @@ class getData(SearchList):
                             response = urlopen( req )
                             forecast_page = response.read()
                             response.close()
+                            # AQI
+                            req = Request( aqi_url, None, headers )
+                            response = urlopen( req )
+                            aqi_page = response.read()
+                            response.close()
                             if self.generator.skin_dict['Extras']['forecast_alert_enabled'] == "1":
                                 # Alerts
                                 req = Request( forecast_alerts_url, None, headers )
@@ -948,14 +963,46 @@ class getData(SearchList):
                             # Combine all into 1 file
                             if self.generator.skin_dict['Extras']['forecast_alert_enabled'] == "1":
                                 try:
-                                    forecast_file_result = json.dumps( {"timestamp": int(time.time()), "current": [json.loads(current_page)], "forecast": [json.loads(forecast_page)], "alerts": [json.loads(alerts_page)]} )
+                                    forecast_file_result = json.dumps( {"timestamp":
+                                                                        int(time.time()),
+                                                                        "current":
+                                                                        [json.loads(current_page)],
+                                                                        "forecast":
+                                                                        [json.loads(forecast_page)],
+                                                                        "alerts":
+                                                                        [json.loads(alerts_page)],
+                                                                        "aqi":
+                                                                        [json.loads(aqi_page)]} )
                                 except:
-                                    forecast_file_result = json.dumps( {"timestamp": int(time.time()), "current": [json.loads(current_page.decode('utf-8'))], "forecast": [json.loads(forecast_page.decode('utf-8'))], "alerts": [json.loads(alerts_page.decode('utf-8'))]} )
+                                    forecast_file_result = json.dumps( {"timestamp":
+                                                                        int(time.time()),
+                                                                        "current":
+                                                                        [json.loads(current_page.decode('utf-8'))],
+                                                                        "forecast":
+                                                                        [json.loads(forecast_page.decode('utf-8'))],
+                                                                        "alerts":
+                                                                        [json.loads(alerts_page.decode('utf-8'))],
+                                                                        "aqi":
+                                                                        [json.loads(aqi_page.decode('utf-8'))]} )
                             else:
                                 try:
-                                    forecast_file_result = json.dumps( {"timestamp": int(time.time()), "current": [json.loads(current_page)], "forecast": [json.loads(forecast_page)]} )
+                                    forecast_file_result = json.dumps( {"timestamp":
+                                                                        int(time.time()),
+                                                                        "current":
+                                                                        [json.loads(current_page)],
+                                                                        "forecast":
+                                                                        [json.loads(forecast_page)],
+                                                                        "aqi":
+                                                                        [json.loads(aqi_page)]} )
                                 except:
-                                    forecast_file_result = json.dumps( {"timestamp": int(time.time()), "current": [json.loads(current_page.decode('utf-8'))], "forecast": [json.loads(forecast_page.decode('utf-8'))]} )
+                                    forecast_file_result = json.dumps( {"timestamp":
+                                                                        int(time.time()),
+                                                                        "current":
+                                                                        [json.loads(current_page.decode('utf-8'))],
+                                                                        "forecast":
+                                                                        [json.loads(forecast_page.decode('utf-8'))],
+                                                                        "aqi":
+                                                                        [json.loads(aqi_page.decode('utf-8'))]} )
                         elif forecast_provider == "darksky":
                             req = Request( forecast_url, None, headers )
                             response = urlopen( req )
@@ -983,6 +1030,39 @@ class getData(SearchList):
                 data = json.load( read_file )
                 
             if forecast_provider == "aeris":
+                aqi = data['aqi'][0]['response'][0]['periods'][0]['aqi']
+                aqi_category = data['aqi'][0]['response'][0]['periods'][0]['category']
+                aqi_time = data['aqi'][0]['response'][0]['periods'][0]['timestamp']
+
+                # Substitute label names if defined in config files, to allow users to supply their own translations
+                # see https://www.aerisweather.com/support/docs/api/reference/endpoints/airquality/
+                if aqi_category == "good" and label_dict["aqi_good"] != "aqi_good":
+                    aqi_category = label_dict["aqi_good"]
+                elif aqi_category == "good" and label_dict["aqi_good"] == "aqi_good":
+                    aqi_category = "good"
+                elif aqi_category == "moderate" and label_dict["aqi_moderate"] != "aqi_moderate":
+                    aqi_category = label_dict["aqi_moderate"]
+                elif aqi_category == "moderate" and label_dict["aqi_moderate"] == "aqi_moderate":
+                    aqi_category = "moderate"
+                elif aqi_category == "usg" and label_dict["aqi_usg"] != "aqi_usg":
+                    aqi_category = label_dict["aqi_usg"]
+                elif aqi_category == "usg" and label_dict["aqi_usg"] == "aqi_usg":
+                    aqi_category = "unhealthy for some"
+                elif aqi_category == "unhealthy" and label_dict["aqi_unhealthy"] != "aqi_unhealthy":
+                    aqi_category = label_dict["aqi_unhealthy"]
+                elif aqi_category == "unhealthy" and label_dict["aqi_unhealthy"] == "aqi_unhealthy":
+                    aqi_category = "unhealthy"
+                elif aqi_category == "very unhealthy" and label_dict["aqi_very_unhealthy"] != "aqi_very_unhealthy":
+                    aqi_category = label_dict["aqi_very_unhealthy"]
+                elif aqi_category == "very unhealthy" and label_dict["aqi_very_unhealthy"] == "aqi_very_unhealthy":
+                    aqi_category = "very unhealthy"
+                elif aqi_category == "hazardous" and label_dict["aqi_hazardous"] != "aqi_hazardous":
+                    aqi_category = label_dict["aqi_hazardous"]
+                elif aqi_category == "hazardous" and label_dict["aqi_hazardous"] == "aqi_hazardous":
+                    aqi_category = "hazardous"
+                else:
+                    aqi_category = "unknown"
+
                 if len(data["current"][0]["response"]) > 0 and self.generator.skin_dict['Extras']['forecast_aeris_use_metar'] == "0":
                     # Non-metar responses do not contain these values. Set them to empty.
                     current_obs_summary = ""
@@ -1399,7 +1479,9 @@ class getData(SearchList):
                                   'earthquake_bearing': eqbearing,
                                   'earthquake_bearing_raw': eqbearing_raw,
                                   'social_html': social_html,
-                                  'custom_css_exists': custom_css_exists }
+                                  'custom_css_exists': custom_css_exists,
+                                  'aqi': aqi,
+                                  'aqi_category': aqi_category }
 
         # Finally, return our extension as a list:
         return [search_list_extension]
@@ -2196,6 +2278,10 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
             
             data = {"weatherRange": True, "obsdata": output_data, "range_unit": obs_unit, "range_unit_label": obs_unit_label}
             
+            return data
+
+        if observation == "aqiChart":
+            data = { "aqiChart": True, "obsdata": [{'y': aqi, 'category': aqi_category}] }
             return data
 
         # Hays chart

--- a/skins/Belchertown/header.html.tmpl
+++ b/skins/Belchertown/header.html.tmpl
@@ -105,6 +105,7 @@
         <script type='text/javascript' src='//code.highcharts.com/stock/highstock.js'></script>
         <script type='text/javascript' src='//code.highcharts.com/highcharts-more.js'></script>
         <script type='text/javascript' src='//code.highcharts.com/modules/exporting.js'></script>
+        <script type='text/javascript' src='//code.highcharts.com/modules/solid-gauge.js'></script>
         <script type='text/javascript' src='//stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js'></script>
         <script type='text/javascript' src='$relative_url/js/belchertown.js?#echo int( time.time() )#'></script>
         #if $page == "pi"

--- a/skins/Belchertown/index.html.tmpl
+++ b/skins/Belchertown/index.html.tmpl
@@ -36,6 +36,8 @@
         #end if
         
         jQuery(document).ready(function() {
+            get_aqi_color( "$aqi" );
+
             get_outTemp_color( "$unit.unit_type.outTemp", "$current.outTemp.formatted" );
             
             rotateThis( "$current.windDir.formatted" );
@@ -190,6 +192,11 @@
                                         <div class="current-obs-text">
                                             $current_obs_summary
                                         </div>
+                                        #if $Extras.has_key("aqi_enabled") and $Extras.aqi_enabled == '1'
+                                        <div class="aqi_outer">
+                                            AQI:  $aqi ($aqi_category)
+                                        </div>
+                                        #end if
                                     </div>
                                     <div class="col-sm-6">
                                         #if $current.appTemp.has_data

--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -197,6 +197,30 @@ function get_outTemp_color( unit, outTemp, returnColor=false ) {
     }
 }
 
+// Change the color of the aqi variable
+function get_aqi_color( aqi, returnColor=false ) {
+    if ( aqi <= 50 ) {
+        var aqi_color = "#71bc3c";
+    } else if ( aqi <= 100 ) {
+        var aqi_color = "rgba(255,174,0,0.9)";
+    } else if ( aqi <= 150 ) {
+        var aqi_color = "rgba(255,127,0,1)";
+    } else if ( aqi <= 200 ) {
+        var aqi_color = "rgba(255,69,69,1)";
+    } else if ( aqi <= 300 ) {
+        var aqi_color = "#b16286";
+    } else if ( aqi > 300 ) {
+        var aqi_color = "#cc241d";
+    }
+
+// Return the color value if requested, otherwise just set the div color
+    if ( returnColor ) {
+        return aqi_color;
+    } else {
+        jQuery(".aqi_outer").css( "color", aqi_color );
+    }
+}
+
 function highcharts_tooltip_factory(obsvalue, point_obsType, highchartsReturn=false, rounding, mirrored=false, numberFormat) {
     // Mirrored values have the negative sign removed
     if ( mirrored ) {
@@ -2118,7 +2142,50 @@ function showChart(json_file, prepend_renderTo=false) {
                     options.series.push(ns);
                 });
             }
-            
+
+            // // If AQI chart is present, configure a special chart
+            if (observation_type == "aqiChart") {
+                options.plotOptions = {
+                    solidgauge: {
+                        dataLabels: {
+                            useHTML: true,
+                            enabled: true, 
+                            y: -30,
+                            borderWidth: 0,
+                            format: '<span style="text-align:center">{y}</span><br><span style="font-size:12px;text-align:center">' + options.series[0].data[0]['category'] + '</span>',
+                            style: {
+                                fontWeight: 'bold',
+                                lineHeight: '0.5em',
+                                textAlign: 'center',
+                                fontSize: '50px',
+                                color: get_aqi_color(options.series[0].data[0]['y'], true),
+                                textOutline: 'none'
+                            }
+                        },
+                        linecap: 'round',
+                        rounded: true
+                    }
+                }
+                options.series[0].data[0].color = get_aqi_color(options.series[0].data[0]['y'], true)
+                options.chart.type = "solidgauge"
+                options.pane = { background: [{
+                        outerRadius: '100%',
+                        innerRadius: '60%',
+                        backgroundColor: '#e6e6e6',
+                        borderWidth: 0
+                    }] 
+                }
+
+                options.yAxis = {
+                    min: 0,
+                    max: 500,
+                    lineColor: null,
+                    tickPositions: []
+                }
+                options.tooltip.enabled = false
+                options.xAxis.crosshair = false
+            }
+
             // If Hays chart is present, configure a special chart to show that data
             if (observation_type == "haysChart") {
                 options.chart.type = "arearange"

--- a/skins/Belchertown/style.css
+++ b/skins/Belchertown/style.css
@@ -1442,6 +1442,11 @@ p.entry-meta {
 	font-size:20px;
 }
 
+.aqi_outer {
+    text-align:center;
+    font-size:20px;
+}
+
 #wxicon {
     display: block;
     margin: 0 auto;


### PR DESCRIPTION
Opening a new pull request to replace the old; all of my tinkering had led to a messy commit history, and my linter removed a bunch of trailing whitespace, leading to hundreds of tiny changes. Sorry about that.

**This pull request adds Air Quality Index information from the Aeris weather forecast API. Forecast must be enabled and set to Aeris for it to work, and the AQI display has to be manually turned on (see below).**

Features:

- AQI is displayed along with the current AQI description. Color automatically changes to reflect AQI. Colors are taken from the official standard, with some adjustments to better match the skin template.
- AQI is read from the nearest AQI station within 25 miles of the weather station's reported position. If no AQI station within 25 miles is available, no AQI will be displayed.
- Users can select whether or not to display AQI. **AQI is turned off by default. Add `aqi_enabled = 1` to the same section as `forecast_enabled` to turn it on.**
- Users can use their own labels for the AQI description. This allows other languages than English to be displayed. The example below shows how you would set it if you wanted French labels. If this section is not set, default US-EPA 2016 standard phrasing will be used automatically. 
```
[StdReport]
    [[Belchertown]]
        [[[Labels]]]
            [[[[Generic]]]]
                aqi_good = bon
                aqi_moderate = modéré
                aqi_usg = mauvais pour certains
                aqi_unhealthy = mauvais
                aqi_very_unhealthy = très mauvais
                aqi_hazardous = dangereux
```
- Users can add a chart to display AQI graphically if they wish. The chart also changes color to match the AQI, and displays the AQI description. Example config:
```
    [[currentAQI]]
        title = Air Quality Index
        [[[aqiChart]]]
```

Here's how it looks:
<img width="400" alt="Screen Shot 2020-12-19 at 1 20 08 PM" src="https://user-images.githubusercontent.com/46248396/102696635-bc807a80-41fd-11eb-83df-841e2764b7a7.png">

<img width="500" alt="Screen Shot 2020-12-19 at 1 20 27 PM" src="https://user-images.githubusercontent.com/46248396/102696639-c1ddc500-41fd-11eb-99c2-890671f7ff6d.png">

<img width="500" alt="Screen Shot 2020-12-19 at 1 22 37 PM" src="https://user-images.githubusercontent.com/46248396/102696644-c73b0f80-41fd-11eb-8243-dca112498166.png">

<img width="500" alt="Screen Shot 2020-12-19 at 1 24 32 PM" src="https://user-images.githubusercontent.com/46248396/102696646-c99d6980-41fd-11eb-8d2b-eb0872326af3.png">
