### PR TITLE
Added gauge chart option

### DIFF
--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -197,7 +197,8 @@ function get_outTemp_color( unit, outTemp, returnColor=false ) {
     }
 }
 
-// Change the color of the aqi variable
+// Change the color of the aqi variable according to US-EPA standards
+// (adjusted to match skin colors better)
 function get_aqi_color( aqi, returnColor=false ) {
     if ( aqi <= 50 ) {
         var aqi_color = "#71bc3c";
@@ -219,6 +220,45 @@ function get_aqi_color( aqi, returnColor=false ) {
     } else {
         jQuery(".aqi_outer").css( "color", aqi_color );
     }
+}
+
+function get_gauge_color( value, options ) {
+    if (options.color1) {
+        if (value > options.color1_position) {
+            var color = options.color1
+        }
+    }
+    if (options.color2) {
+        if (value > options.color2_position) {
+            var color = options.color2
+        }
+    }
+    if (options.color3) {
+        if (value > options.color3_position) {
+            var color = options.color3
+        }
+    }
+    if (options.color4) {
+        if (value > options.color4_position) {
+            var color = options.color4
+        }
+    }
+    if (options.color5) {
+        if (value > options.color5_position) {
+            var color = options.color5
+        }
+    }
+    if (options.color6) {
+        if (value > options.color6_position) {
+            var color = options.color6
+        }
+    }
+    if (options.color7) {
+        if (value > options.color7_position){
+            var color = options.color7
+        }
+    }
+    return color
 }
 
 function highcharts_tooltip_factory(obsvalue, point_obsType, highchartsReturn=false, rounding, mirrored=false, numberFormat) {
@@ -2148,8 +2188,99 @@ function showChart(json_file, prepend_renderTo=false) {
                 });
             }
 
-            // // If AQI chart is present, configure a special chart
+            // Configure gauge chart formatting
+            if (options.chart.type == "gauge") {
+                // Highcharts does not allow the guage background to have rounded ends. To get around
+                // this, define a "dummy" series that fills the gauge with the appropriate color.
+                // This way, the ends are rounded if the user specifies.
+                //
+                // Gauge chart works best with only one data point, so the most recent (last) data point
+                // is used
+                options.series[0].data = [{
+                    y: 9999999,
+                    color: '#e6e6e6',
+                    className: 'highcharts-pane',
+                    zIndex: 0,
+                    dataLabels: {enabled: false}
+                }, {
+                    y: options.series[0].data.pop()[1], 
+                    color: options.series[0].color,
+                }]
+                options.chart.type = "solidgauge"
+                options.pane = { 
+                    startAngle: -140,
+                    endAngle: 140,
+                    background: [{
+                        outerRadius: 0,
+                        innerRadius: 0,
+                    }] 
+                }
+                // If user has set colors_enabled, change the color according to the value
+                if (options.series[0].colors_enabled) {
+                    options.series[0].data[1].color = get_gauge_color(options.series[0].data[1]["y"], options.series[0])
+                }
+                options.plotOptions = {
+                    solidgauge: {
+                        dataLabels: {
+                            useHTML: true,
+                            enabled: true, 
+                            y: -20,
+                            borderWidth: 0,
+                            format: "<span style='text-align:center'>{y:.#f}</span><br><span style='font-size:20px;text-align:center'>" + unit_label_array[observation_type] + '</span>',
+                            style: {
+                                fontWeight: 'bold',
+                                lineHeight: '0.5em',
+                                textAlign: 'center',
+                                fontSize: '50px',
+                                // Match color if set by user
+                                color: options.series[0].data[1].color,
+                                textOutline: 'none'
+                            }
+                        },
+                    }
+                }
+                options.yAxis = {
+                    min: 0,
+                    max: 100,
+                    lineColor: null,
+                    tickPositions: []
+                }
+                // Override default max and min if user has specified
+                if (options.series[0].yAxis_max) {
+                    options.yAxis.max = options.series[0].yAxis_max;
+                }
+                if (options.series[0].yAxis_min) {
+                    options.yAxis.min = options.series[0].yAxis_min;
+                }
+                options.tooltip.enabled = false
+                options.xAxis.crosshair = false
+            }
+
+            // If AQI chart is present, configure a special chart
             if (observation_type == "aqiChart") {
+                // Highcharts does not allow the guage background to have rounded ends. To get around
+                // this, define a "dummy" series that fills the gauge with the appropriate color.
+                // This way, the ends are rounded if the user specifies.
+                options.series[0].data = [{
+                    y: 500,
+                    color: '#e6e6e6',
+                    className: 'highcharts-pane',
+                    zIndex: 0,
+                    dataLabels: {enabled: false}
+                }, {
+                    y: options.series[0].data[0]['y'],
+                    color: get_aqi_color(options.series[0].data[0]['y'], true),
+                    category: options.series[0].data[0]['category']
+                }]
+                options.chart.type = "solidgauge"
+                options.pane = {
+                    startAngle: -140,
+                    endAngle: 140,
+                    background: [{
+                        outerRadius: 0,
+                        innerRadius: 0,
+                    }] 
+                }
                 options.plotOptions = {
                     solidgauge: {
                         dataLabels: {
@@ -2157,13 +2288,13 @@ function showChart(json_file, prepend_renderTo=false) {
                             enabled: true, 
                             y: -30,
                             borderWidth: 0,
-                            format: '<span style="text-align:center">{y}</span><br><span style="font-size:12px;text-align:center">' + options.series[0].data[0]['category'] + '</span>',
+                            format: '<span style="text-align:center">{y}</span><br><span style="font-size:12px;text-align:center">' + options.series[0].data[1]['category'] + '</span>',
                             style: {
                                 fontWeight: 'bold',
                                 lineHeight: '0.5em',
                                 textAlign: 'center',
                                 fontSize: '50px',
-                                color: get_aqi_color(options.series[0].data[0]['y'], true),
+                                color: options.series[0].data[1].color,
                                 textOutline: 'none'
                             }
                         },
@@ -2171,16 +2302,6 @@ function showChart(json_file, prepend_renderTo=false) {
                         rounded: true
                     }
                 }
-                options.series[0].data[0].color = get_aqi_color(options.series[0].data[0]['y'], true)
-                options.chart.type = "solidgauge"
-                options.pane = { background: [{
-                        outerRadius: '100%',
-                        innerRadius: '60%',
-                        backgroundColor: '#e6e6e6',
-                        borderWidth: 0
-                    }] 
-                }
-
                 options.yAxis = {
                     min: 0,
                     max: 500,
@@ -2203,20 +2324,16 @@ function showChart(json_file, prepend_renderTo=false) {
                         }
                     }
                 };
-
                 // Find min and max of the series data for the yAxis min and max
                 var maximum_flattened = [];
                 options.series[0].data.forEach( seriesData => {
                     maximum_flattened.push(seriesData[2]);
                 });
                 var range_max = Math.max(...maximum_flattened);
-                
                 if (options.series[0].yAxis_softMax) {
                     var range_max = options.series[0].yAxis_softMax;
                 }
-                
                 options.legend = { "enabled": false }
-
                 options.yAxis = {
                     showFirstLabel: false,
                     tickInterval: 2,
@@ -2232,7 +2349,6 @@ function showChart(json_file, prepend_renderTo=false) {
                         y: 0
                     },
                 }
-
                 options.tooltip = {
                     split: false,
                     shared: true,
@@ -2247,7 +2363,6 @@ function showChart(json_file, prepend_renderTo=false) {
                         });
                     }
                 }
-
                 var currentSeries = options.series;
                 var currentSeriesData = options.series[0].data;
                 var range_unit = options.series[0].range_unit;


### PR DESCRIPTION
Building off the AQI Chart option, this is a general gauge-style chart that can be used to show any data point, not just AQI. Good for showing values on a set scale (e.g. humidity).  **This pull request also changes the style of the Aeris AQI gauge to match.**

### How to use:
The simplest configuration will give a gauge chart from 0-100 with the specified value:
```
[[exampleGauge]]
    title = Example gauge chart
    type = gauge
    [[[outTemp]]]
```
![D8B875B4-14AF-4DC1-B7CC-FCC3388A80AF](https://user-images.githubusercontent.com/46248396/103161671-638f8400-47b3-11eb-8444-4b5bf8c056f4.jpeg)


Users can specify rounded edges if they wish, and also change the color:
```
    [[exampleGauge]]
        title = Example gauge chart
        type = gauge
        [[[outTemp]]]
            rounded = 1
            color = "#f7a35c"
```
![F6457958-CF52-49CE-B949-C66648349552](https://user-images.githubusercontent.com/46248396/103161702-c97c0b80-47b3-11eb-89be-9c923e8f6f4b.jpeg)


However, users can also specify a list of threshold colors, so the gauge will change colors dynamically depending on the value being graphed. Enable by setting `colors_enabled = 1`. 

Users can set up to 7 colors. Both the color and the color position must be set. When the value rises above a particular color position, the corresponding color will be set. For example, wind gust speed can be color-coded as follows (note the y-axis max and min have been manually set to better match a range of possible wind speeds). In this example, the wind speed has just increased above `color4_position`, so `color4` is the one that gets set:
```
    [[exampleGauge]]
        title = Example gauge chart
        type = gauge
        [[[windGust]]]                                                                                                                        
                rounded = 1      
                colors_enabled = 1                                                                                                                
                color1_position = 3                                                                                                              
                color1 = "#1278c8"                                                                                                               
                color2_position = 7                                                                                                              
                color2 = "#1fafdd"                                                                                                               
                color3_position = 12                                                                                                             
                color3 = "#71bc3c"                                                                                                               
                color4_position = 20                                                                                                             
                color4 = "#ffae00"                                                                                                               
                color5_position = 30                                                                                                             
                color5 = "#ff7f00"                                                                                                               
                color6_position = 40                                                                                                             
                color6 = "#ff4500"                                                                                                               
                color7_position = 50                                                                                                             
                color7 = "#9f00c5"
                yAxis_min = 0
                yAxis_max = 70
```
![B20AA7AF-89F1-4838-BAC1-A7223940572A](https://user-images.githubusercontent.com/46248396/103161628-a4d36400-47b2-11eb-89b9-88ddd2164b17.jpeg)

Users can use the built-in Belchertown aggregation functions to graph maximums, averages, etc. For example, setting `time_length = 2629800 `, `aggregate_interval = 2629800` (1 month in seconds), and `aggregate_type = min` gets us the minimum temperature for the past month:
![07B3AEFC-17B4-46C6-8661-1F805074BE0F](https://user-images.githubusercontent.com/46248396/103161635-b1f05300-47b2-11eb-8a2e-bd9d565c724a.jpeg)

Maximum wind speed over the past 24 hours (`time_length = 86400`, `aggregate_interval = 86400`, `aggregate_type = max`):
![6F1B90B3-A452-4CDB-BE8D-4538B0241DA8](https://user-images.githubusercontent.com/46248396/103161638-c16f9c00-47b2-11eb-8029-e0c571c1ac66.jpeg)

You can of course set fewer than 7 colors—for example, just red/green. For example, I set my signal strength indicator on a scale from 90-100%. Green as long as it’s above 98%, red below that.

I was having a decimal point issue that was fixed very nicely by #491–thank you!!