### PR TITLE
StringFormat issue in Charts

### DIFF
--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -2439,7 +2439,7 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
                 usage_round = int(self.skin_dict['Units']['StringFormats'].get(obs_vt[1], "1f")[-2])
                 obs_round_vt = [round(x,usage_round) if x is not None else None for x in obs_vt[0]]
             else:
-                usage_round = int(self.skin_dict['Units']['StringFormats'].get(obs_vt[2], "2f")[-2])
+                usage_round = int(self.skin_dict['Units']['StringFormats'].get(obs_vt[1], "2f")[-2])
                 obs_round_vt = [self.round_none(x, usage_round) for x in obs_vt[0]]
             
         # "Today" charts, "timespan_specific" charts and floating timespan charts have the point timestamp on the stop time so we don't see the 


### PR DESCRIPTION
Resolves an issue where StringFormats lookup was based on the group instead of the observation. I think this would result in all observations being rounded to 2 decimal places in the charts.
I noticed this when trying to show battery voltage values to 3 decimal places