### PR TITLE
Added beaufort and knots windspeed options

### DIFF
--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -2083,6 +2083,29 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
                         elif windData[1] >= 22:
                             group_6_windDir.append( windData[0] )
                             group_6_windSpeed.append( windData[1] )
+                    elif windSpeed_unit == "beaufort":
+                        if windData[1] <= 1:
+                            group_0_windDir.append( windData[0] )
+                            group_0_windSpeed.append( windData[1] )
+                        elif windData[1] == 2:
+                            group_1_windDir.append( windData[0] )
+                            group_1_windSpeed.append( windData[1] )
+                        elif windData[1] == 3:
+                            group_2_windDir.append( windData[0] )
+                            group_2_windSpeed.append( windData[1] )
+                        elif windData[1] == 4:
+                            group_3_windDir.append( windData[0] )
+                            group_3_windSpeed.append( windData[1] )
+                        elif windData[1] == 5:
+                            group_4_windDir.append( windData[0] )
+                            group_4_windSpeed.append( windData[1] )
+                        elif windData[1] == 6:
+                            group_5_windDir.append( windData[0] )
+                            group_5_windSpeed.append( windData[1] )
+                        elif windData[1] >= 7:
+                            group_6_windDir.append( windData[0] )
+                            group_6_windSpeed.append( windData[1] )
+
 
             # Get the windRose data
             group_0_series_data = self.create_windrose_data( group_0_windDir, group_0_windSpeed )
@@ -2158,7 +2181,15 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
                 group_4_speedRange = "11-16"
                 group_5_speedRange = "17-21"
                 group_6_speedRange = "22+"
-            
+            elif windSpeed_unit == "beaufort":
+                group_0_speedRange = "0"
+                group_1_speedRange = "1"
+                group_2_speedRange = "2"
+                group_3_speedRange = "3"
+                group_4_speedRange = "4"
+                group_5_speedRange = "5"
+                group_6_speedRange = "6+"
+
             group_0_name = "%s %s" % (group_0_speedRange, windSpeed_unit_label)
             group_1_name = "%s %s" % (group_1_speedRange, windSpeed_unit_label)
             group_2_name = "%s %s" % (group_2_speedRange, windSpeed_unit_label)

--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -214,7 +214,7 @@ function get_aqi_color( aqi, returnColor=false ) {
         var aqi_color = "#cc241d";
     }
 
-// Return the color value if requested, otherwise just set the div color
+    // Return the color value if requested, otherwise just set the div color
     if ( returnColor ) {
         return aqi_color;
     } else {
@@ -259,6 +259,37 @@ function get_gauge_color( value, options ) {
         }
     }
     return color
+}
+
+function beaufort(windspeed) {
+    // Given windspeed in knots, converts to Beaufort scale
+    if (windspeed <= 1) {
+        return 0
+    } else if (windspeed <= 3) {
+        return 1
+    } else if (windspeed <=6) {
+        return 2
+    } else if (windspeed <=10) {
+        return 3
+    } else if (windspeed <=15) {
+        return 4
+    } else if (windspeed <=21) {
+        return 5
+    } else if (windspeed <=27) {
+        return 6
+    } else if (windspeed <=33) {
+        return 7
+    } else if (windspeed <=40) {
+        return 8
+    } else if (windspeed <=47) {
+        return 9
+    } else if (windspeed <=55) {
+        return 10
+    } else if (windspeed <=63) {
+        return 11
+    } else if (windspeed > 63) {
+        return 12
+    }
 }
 
 function highcharts_tooltip_factory(obsvalue, point_obsType, highchartsReturn=false, rounding, mirrored=false, numberFormat) {
@@ -1065,6 +1096,11 @@ function update_forecast_data( data ) {
     forecast_provider = "$Extras.forecast_provider";
     belchertown_debug("Forecast: Provider is " + forecast_provider);
     belchertown_debug("Forecast: Updating data");
+    #if $Extras.has_key('forecast_wind_units')
+        forecast_wind_units = "$Extras.forecast_wind_units"
+    #else
+        forecast_wind_units = ""
+    #end if
     
     forecast_row = [];
     
@@ -1162,6 +1198,42 @@ function update_forecast_data( data ) {
                 var snow_depth = 0;
                 var snow_unit = "";
             }
+
+            if ( data["flags"]["units"].toLowerCase() == "us" || data["flags"]["units"].toLowerCase() == "us" ) {
+                // Wind speed is given in mph
+                if ( forecast_wind_units == "beaufort" ) {
+                    // User wants Beaufort wind scale, so convert mph to knots and then to Beaufort
+                    data["daily"]["data"][i]["windSpeed"] = beaufort(data["daily"]["data"][i]["windSpeed"]*0.8689758)
+                    data["daily"]["data"][i]["windGust"] = beaufort(data["daily"]["data"][i]["windGust"]*0.8689758)
+                } else if ( forecast_wind_units == "knots" ) {
+                    // User wants knots, so convert mph to knots
+                    data["daily"]["data"][i]["windSpeed"] = data["daily"]["data"][i]["windSpeed"]*0.8689758
+                    data["daily"]["data"][i]["windGust"] = data["daily"]["data"][i]["windGust"]*0.8689758
+                }
+            } else if ( data["flags"]["units"].toLowerCase() == "ca" ) {
+                // Wind speed is given in kph
+                if ( forecast_wind_units == "beaufort" ) {
+                    // User wants Beaufort wind scale, so convert kph to knots and then to Beaufort
+                    data["daily"]["data"][i]["windSpeed"] = beaufort(data["daily"]["data"][i]["windSpeed"]*0.5399565)
+                    data["daily"]["data"][i]["windGust"] = beaufort(data["daily"]["data"][i]["windGust"]*0.5399565)
+                } else if ( forecast_wind_units == "knots" ) {
+                    // User wants knots, so convert kph to knots
+                    data["daily"]["data"][i]["windSpeed"] = data["daily"]["data"][i]["windSpeed"]*0.5399565
+                    data["daily"]["data"][i]["windGust"] = data["daily"]["data"][i]["windGust"]*0.5399565
+                }
+            } else if ( data["flags"]["units"].toLowerCase() == "si" ) {
+                // Wind speed is given in m/s
+                if ( forecast_wind_units == "beaufort" ) {
+                    // User wants Beaufort wind scale, so convert m/s to knots and then to Beaufort
+                    data["daily"]["data"][i]["windSpeed"] = beaufort(data["daily"]["data"][i]["windSpeed"]*1.943844)
+                    data["daily"]["data"][i]["windGust"] = beaufort(data["daily"]["data"][i]["windGust"]*1.943844)
+                } else if ( forecast_wind_units == "knots" ) {
+                    // User wants knots, so convert m/s to knots
+                    data["daily"]["data"][i]["windSpeed"] = data["daily"]["data"][i]["windSpeed"]*1.943844
+                    data["daily"]["data"][i]["windGust"] = data["daily"]["data"][i]["windGust"]*1.943844
+                }
+            }
+
             var darksky_link_units = data["flags"]["units"].toLowerCase().concat("12"); // Currently the DarkSky forecast link uses a "{unit}12" string in the URL.
             
             #if $Extras.has_key("darksky_lang")
@@ -1241,6 +1313,12 @@ function update_forecast_data( data ) {
                 // si = meters per second. MPS is KPH / 3.6
                 windSpeed = data["forecast"][0]["response"][0]["periods"][i]["windSpeedKPH"] / 3.6;
                 windGust = data["forecast"][0]["response"][0]["periods"][i]["windGustKPH"] / 3.6;
+            } else if ( forecast_wind_units == "knot" ) {
+                windSpeed = data["forecast"][0]["response"][0]["periods"][i]["windSpeedKTS"];
+                windGust = data["forecast"][0]["response"][0]["periods"][i]["windGustKTS"];
+            } else if ( forecast_wind_units == "beaufort" ) {
+                windSpeed = beaufort(data["forecast"][0]["response"][0]["periods"][i]["windSpeedKTS"]);
+                windGust = beaufort(data["forecast"][0]["response"][0]["periods"][i]["windGustKTS"]);
             } else {
                 // us and uk2 and default = mph
                 windSpeed = data["forecast"][0]["response"][0]["periods"][i]["windSpeedMPH"];
@@ -1629,6 +1707,14 @@ function update_current_wx(data) {
     if ( data.hasOwnProperty("windSpeed_mps") ) {
         jQuery(".curwindspeed").html( parseFloat(parseFloat(data["windSpeed_mps"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}) );
     }
+    // Windspeed Beaufort
+    if ( data.hasOwnProperty("windSpeed_beaufort") ) {
+        jQuery(".curwindspeed").html( parseFloat(parseFloat(data["windSpeed_beaufort"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}) );
+    }
+    // Windspeed knots
+    if ( data.hasOwnProperty("windSpeed_knot") ) {
+        jQuery(".curwindspeed").html( parseFloat(parseFloat(data["windSpeed_knot"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}) );
+    }
     
     // Wind Gust US
     // May not be provided in mqtt, but just in case.
@@ -1642,6 +1728,14 @@ function update_current_wx(data) {
     // Wind Gust METRICWX
     if ( data.hasOwnProperty("windGust_mps") ) {
         jQuery(".curwindgust").html( parseFloat(parseFloat(data["windGust_mps"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windGust"], maximumFractionDigits: unit_rounding_array["windGust"]}) );
+    }
+    // Wind Gust Beaufort
+    if ( data.hasOwnProperty("windGust_beaufort") ) {
+        jQuery(".curwindspeed").html( parseFloat(parseFloat(data["windGust_beaufort"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}) );
+    }
+    // Windspeed knots
+    if ( data.hasOwnProperty("windGust_knot") ) {
+        jQuery(".curwindspeed").html( parseFloat(parseFloat(data["windGust_knot"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}) );
     }
     
     // Windchill US


### PR DESCRIPTION
Added support for displaying wind speed in both knots and Beaufort scale. weewx had this functionality built in already, but Belchertown didn’t have the ability to display it in the wind rose graph, in the live MQTT data, and in the forecast.

**IMPORTANT: there was previously a bug in weewx that prevented processing of Beaufort values (specifically the wind vector graph). That bug has since been fixed but hasn’t been officially released yet. If you specify Beaufort units, you may get errors from weewx until that bug fix is released. You can either install the latest development version of weewx, or just ignore the errors—Belchertown should work fine.**

Up to three configuration changes are necessary:

1. Switch over units to Beaufort or knots globally in weewx.conf. Config for Beaufort:
```
[StdReport]
    [[Defaults]]
        [[[Units]]]
            [[[[Groups]]]]
                group_speed = beaufort
            [[[[StringFormats]]]]
                beaufort = %.0f
            [[[[Labels]]]]
                beaufort = " Beaufort"
```
Config for knots (simpler because the labels are already built in to weewx):
```
[StdReport]
    [[Defaults]]
        [[[Units]]]
            [[[[Groups]]]]
                group_speed = knot
```
You can also change these settings just for Belchertown if you want—check weewx documentation for how to set units for a single report.

2. If forecast is displayed, you’ll also need to tell Belchertown to convert those units, since they’re not coming from weewx. Do that by setting `forecast_wind_units = beaufort` or `forecast_wind_units = knot`. That will cause either the Aeris or DarkSky units to switch over to the specified unit. **Keep in mind the forecast gets its unit labels from the units being used for the skin. If the skin is set to display knots but `forecast_wind_units` is not set to knots as well, the forecast will keep displaying the previous unit, even though the label will say “knots.”**

3. If you’re using MQTT to display real-time updates, you’ll also need to tell the skin that so it can convert the units as they arrive. Do that by modifying the MQTT section:
```
[StdRESTful]
    [[MQTT]]
        [[[inputs]]]
            [[[[windSpeed]]]]
                name = windSpeed_beaufort (OR windSpeed_knot)
                units = beaufort (OR knots)
            [[[[windGust]]]]
                name = windGust_beaufort (OR windGust_knot)
                units = beaufort (OR knots)
```

I don’t have a Dark Sky API key, so I can’t test whether or not the Dark Sky code is working. If anyone wants to help me out on that, it’d be much appreciated!