### PR TITLE
Beaufort category display

### DIFF
--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -1069,6 +1069,59 @@ class getData(SearchList):
                 else:
                     aqi_category = "unknown"
 
+                if label_dict["beaufort0"] != "beaufort0":
+                    beaufort0 = label_dict["beaufort0"]
+                else:
+                    beaufort0 = "calm"
+                if label_dict["beaufort1"] != "beaufort1":
+                    beaufort1 = label_dict["beaufort1"]
+                else:
+                    beaufort1 = "light air"
+                if label_dict["beaufort2"] != "beaufort2":
+                    beaufort2 = label_dict["beaufort2"]
+                else:
+                    beaufort2 = "light breeze"
+                if label_dict["beaufort3"] != "beaufort3":
+                    beaufort3 = label_dict["beaufort3"]
+                else:
+                    beaufort3 = "gentle breeze"
+                if label_dict["beaufort4"] != "beaufort4":
+                    beaufort4 = label_dict["beaufort4"]
+                else:
+                    beaufort4 = "moderate breeze"
+                if label_dict["beaufort5"] != "beaufort5":
+                    beaufort5 = label_dict["beaufort5"]
+                else:
+                    beaufort5 = "fresh breeze"
+                if label_dict["beaufort6"] != "beaufort6":
+                    beaufort6 = label_dict["beaufort6"]
+                else:
+                    beaufort6 = "strong breeze"
+                if label_dict["beaufort7"] != "beaufort7":
+                    beaufort7 = label_dict["beaufort7"]
+                else:
+                    beaufort7 = "near gale"
+                if label_dict["beaufort8"] != "beaufort8":
+                    beaufort8 = label_dict["beaufort8"]
+                else:
+                    beaufort8 = "gale"
+                if label_dict["beaufort9"] != "beaufort9":
+                    beaufort9 = label_dict["beaufort9"]
+                else:
+                    beaufort9 = "strong gale"
+                if label_dict["beaufort10"] != "beaufort10":
+                    beaufort10 = label_dict["beaufort10"]
+                else:
+                    beaufort10 = "storm"
+                if label_dict["beaufort11"] != "beaufort11":
+                    beaufort11 = label_dict["beaufort11"]
+                else:
+                    beaufort11 = "violent storm"
+                if label_dict["beaufort12"] != "beaufort12":
+                    beaufort12 = label_dict["beaufort12"]
+                else:
+                    beaufort12 = "hurricane force"
+
                 if len(data["current"][0]["response"]) > 0 and self.generator.skin_dict['Extras']['forecast_aeris_use_metar'] == "0":
                     # Non-metar responses do not contain these values. Set them to empty.
                     current_obs_summary = ""
@@ -1481,7 +1534,20 @@ class getData(SearchList):
                                   'custom_css_exists': custom_css_exists,
                                   'aqi': aqi,
                                   'aqi_category': aqi_category,
-                                  'aqi_location': aqi_location }
+                                  'aqi_location': aqi_location,
+                                  'beaufort0': beaufort0,
+                                  'beaufort1': beaufort1,
+                                  'beaufort2': beaufort2,
+                                  'beaufort3': beaufort3,
+                                  'beaufort4': beaufort4,
+                                  'beaufort5': beaufort5,
+                                  'beaufort6': beaufort6,
+                                  'beaufort7': beaufort7,
+                                  'beaufort8': beaufort8,
+                                  'beaufort9': beaufort9,
+                                  'beaufort10': beaufort10,
+                                  'beaufort11': beaufort11,
+                                  'beaufort12': beaufort12}
 
         # Finally, return our extension as a list:
         return [search_list_extension]

--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -401,11 +401,14 @@ class getData(SearchList):
         at_outTemp_max_range_query = wx_manager.getSql( 'SELECT dateTime, ROUND( (max - min), 1 ) as total, ROUND( min, 1 ) as min, ROUND( max, 1 ) as max FROM archive_day_outTemp WHERE min IS NOT NULL AND max IS NOT NULL ORDER BY total DESC LIMIT 1;' )
         at_outTemp_min_range_query = wx_manager.getSql( 'SELECT dateTime, ROUND( (max - min), 1 ) as total, ROUND( min, 1 ) as min, ROUND( max, 1 ) as max FROM archive_day_outTemp WHERE min IS NOT NULL AND max IS NOT NULL ORDER BY total ASC LIMIT 1;' )
         
-        # Find the group_name for outTemp
+        # Find the group_name for outTemp in database
         outTemp_unit = converter.group_unit_dict["group_temperature"]
-        
-        # Find the number of decimals to round to
-        outTemp_round = self.generator.skin_dict['Units']['StringFormats'].get(outTemp_unit, "%.1f")
+       
+        # Find the group_name for outTemp from the skin.conf
+        skin_outTemp_unit = self.generator.converter.group_unit_dict["group_temperature"]
+            
+        # Find the number of decimals to round to based on the skin.conf
+        outTemp_round = self.generator.skin_dict['Units']['StringFormats'].get(skin_outTemp_unit, "%.1f")
 
         # Largest Daily Temperature Range Conversions
         # Max temperature for this day
@@ -463,12 +466,15 @@ class getData(SearchList):
         
         
         # Rain lookups
-        # Find the group_name for rain
+        # Find the group_name for rain in database
         rain_unit = converter.group_unit_dict["group_rain"]
         
-        # Find the number of decimals to round to
-        rain_round = self.generator.skin_dict['Units']['StringFormats'].get(rain_unit, "%.2f")
-        
+        # Find the group_name for rain in the skin.conf
+        skin_rain_unit = self.generator.converter.group_unit_dict["group_rain"]
+
+        # Find the number of decimals to round the result based on the skin.conf
+        rain_round = self.generator.skin_dict['Units']['StringFormats'].get(skin_rain_unit, "%.2f")
+       
         # Rainiest Day
         rainiest_day_query = wx_manager.getSql( 'SELECT dateTime, sum FROM archive_day_rain WHERE dateTime >= %s ORDER BY sum DESC LIMIT 1;' % year_start_epoch )
         if rainiest_day_query is not None:

--- a/skins/Belchertown/index.html.tmpl
+++ b/skins/Belchertown/index.html.tmpl
@@ -37,6 +37,7 @@
         
         jQuery(document).ready(function() {
             get_aqi_color( "$aqi" );
+            jQuery(".beaufort").html( beaufort_cat( $current.windSpeed.beaufort.toString(addLabel=False) ) );
 
             get_outTemp_color( "$unit.unit_type.outTemp", "$current.outTemp.formatted" );
             
@@ -271,6 +272,11 @@
                                             <tr>
                                                 <td class="mph" colspan="3">$unit.label.windSpeed</td>
                                             </tr>
+                                            #if $Extras.has_key("beaufort_category") and $Extras.beaufort_category == '1'
+                                            <tr>
+                                                <td class="beaufort" colspan="4"></td>
+                                            </tr>
+                                            #end if
                                         </tbody>
                                     </table>
                                 </div>

--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -261,7 +261,7 @@ function get_gauge_color( value, options ) {
     return color
 }
 
-function beaufort(windspeed) {
+function kts_to_beaufort(windspeed) {
     // Given windspeed in knots, converts to Beaufort scale
     if (windspeed <= 1) {
         return 0
@@ -289,6 +289,38 @@ function beaufort(windspeed) {
         return 11
     } else if (windspeed > 63) {
         return 12
+    }
+}
+
+function beaufort_cat(beaufort) {
+    // Given Beaufort number, returns category description
+    switch (beaufort) {
+        case 0:
+            return "$beaufort0"
+        case 1:
+            return "$beaufort1"
+        case 2:
+            return "$beaufort2"
+        case 3:
+            return "$beaufort3"
+        case 4:
+            return "$beaufort4"
+        case 5:
+            return "$beaufort5"
+        case 6:
+            return "$beaufort6"
+        case 7:
+            return "$beaufort7"
+        case 8:
+            return "$beaufort8"
+        case 9:
+            return "$beaufort9"
+        case 10:
+            return "$beaufort10"
+        case 11:
+            return "$beaufort11"
+        case 12:
+            return "$beaufort12"
     }
 }
 
@@ -1096,11 +1128,6 @@ function update_forecast_data( data ) {
     forecast_provider = "$Extras.forecast_provider";
     belchertown_debug("Forecast: Provider is " + forecast_provider);
     belchertown_debug("Forecast: Updating data");
-    #if $Extras.has_key('forecast_wind_units')
-        forecast_wind_units = "$Extras.forecast_wind_units"
-    #else
-        forecast_wind_units = ""
-    #end if
     
     forecast_row = [];
     
@@ -1201,33 +1228,33 @@ function update_forecast_data( data ) {
 
             if ( data["flags"]["units"].toLowerCase() == "us" || data["flags"]["units"].toLowerCase() == "us" ) {
                 // Wind speed is given in mph
-                if ( forecast_wind_units == "beaufort" ) {
+                if ( "$unit.unit_type.windSpeed" == "beaufort" ) {
                     // User wants Beaufort wind scale, so convert mph to knots and then to Beaufort
-                    data["daily"]["data"][i]["windSpeed"] = beaufort(data["daily"]["data"][i]["windSpeed"]*0.8689758)
-                    data["daily"]["data"][i]["windGust"] = beaufort(data["daily"]["data"][i]["windGust"]*0.8689758)
-                } else if ( forecast_wind_units == "knots" ) {
+                    data["daily"]["data"][i]["windSpeed"] = kts_to_beaufort(data["daily"]["data"][i]["windSpeed"]*0.8689758)
+                    data["daily"]["data"][i]["windGust"] = kts_to_beaufort(data["daily"]["data"][i]["windGust"]*0.8689758)
+                } else if ( "$unit.unit_type.windSpeed" == "knot" ) {
                     // User wants knots, so convert mph to knots
                     data["daily"]["data"][i]["windSpeed"] = data["daily"]["data"][i]["windSpeed"]*0.8689758
                     data["daily"]["data"][i]["windGust"] = data["daily"]["data"][i]["windGust"]*0.8689758
                 }
             } else if ( data["flags"]["units"].toLowerCase() == "ca" ) {
                 // Wind speed is given in kph
-                if ( forecast_wind_units == "beaufort" ) {
+                if ( "$unit.unit_type.windSpeed" == "beaufort" ) {
                     // User wants Beaufort wind scale, so convert kph to knots and then to Beaufort
-                    data["daily"]["data"][i]["windSpeed"] = beaufort(data["daily"]["data"][i]["windSpeed"]*0.5399565)
-                    data["daily"]["data"][i]["windGust"] = beaufort(data["daily"]["data"][i]["windGust"]*0.5399565)
-                } else if ( forecast_wind_units == "knots" ) {
+                    data["daily"]["data"][i]["windSpeed"] = kts_to_beaufort(data["daily"]["data"][i]["windSpeed"]*0.5399565)
+                    data["daily"]["data"][i]["windGust"] = kts_to_beaufort(data["daily"]["data"][i]["windGust"]*0.5399565)
+                } else if ( "$unit.unit_type.windSpeed" == "knots" ) {
                     // User wants knots, so convert kph to knots
                     data["daily"]["data"][i]["windSpeed"] = data["daily"]["data"][i]["windSpeed"]*0.5399565
                     data["daily"]["data"][i]["windGust"] = data["daily"]["data"][i]["windGust"]*0.5399565
                 }
             } else if ( data["flags"]["units"].toLowerCase() == "si" ) {
                 // Wind speed is given in m/s
-                if ( forecast_wind_units == "beaufort" ) {
+                if ( "$unit.unit_type.windSpeed" == "beaufort" ) {
                     // User wants Beaufort wind scale, so convert m/s to knots and then to Beaufort
-                    data["daily"]["data"][i]["windSpeed"] = beaufort(data["daily"]["data"][i]["windSpeed"]*1.943844)
-                    data["daily"]["data"][i]["windGust"] = beaufort(data["daily"]["data"][i]["windGust"]*1.943844)
-                } else if ( forecast_wind_units == "knots" ) {
+                    data["daily"]["data"][i]["windSpeed"] = kts_to_beaufort(data["daily"]["data"][i]["windSpeed"]*1.943844)
+                    data["daily"]["data"][i]["windGust"] = kts_to_beaufort(data["daily"]["data"][i]["windGust"]*1.943844)
+                } else if ( "$unit.unit_type.windSpeed" == "knots" ) {
                     // User wants knots, so convert m/s to knots
                     data["daily"]["data"][i]["windSpeed"] = data["daily"]["data"][i]["windSpeed"]*1.943844
                     data["daily"]["data"][i]["windGust"] = data["daily"]["data"][i]["windGust"]*1.943844
@@ -1313,12 +1340,12 @@ function update_forecast_data( data ) {
                 // si = meters per second. MPS is KPH / 3.6
                 windSpeed = data["forecast"][0]["response"][0]["periods"][i]["windSpeedKPH"] / 3.6;
                 windGust = data["forecast"][0]["response"][0]["periods"][i]["windGustKPH"] / 3.6;
-            } else if ( forecast_wind_units == "knot" ) {
+            } else if ( "$unit.unit_type.windSpeed" == "knot" ) {
                 windSpeed = data["forecast"][0]["response"][0]["periods"][i]["windSpeedKTS"];
                 windGust = data["forecast"][0]["response"][0]["periods"][i]["windGustKTS"];
-            } else if ( forecast_wind_units == "beaufort" ) {
-                windSpeed = beaufort(data["forecast"][0]["response"][0]["periods"][i]["windSpeedKTS"]);
-                windGust = beaufort(data["forecast"][0]["response"][0]["periods"][i]["windGustKTS"]);
+            } else if ( "$unit.unit_type.windSpeed" == "beaufort" ) {
+                windSpeed = kts_to_beaufort(data["forecast"][0]["response"][0]["periods"][i]["windSpeedKTS"]);
+                windGust = kts_to_beaufort(data["forecast"][0]["response"][0]["periods"][i]["windGustKTS"]);
             } else {
                 // us and uk2 and default = mph
                 windSpeed = data["forecast"][0]["response"][0]["periods"][i]["windSpeedMPH"];
@@ -1715,6 +1742,8 @@ function update_current_wx(data) {
     if ( data.hasOwnProperty("windSpeed_knot") ) {
         jQuery(".curwindspeed").html( parseFloat(parseFloat(data["windSpeed_knot"])).toLocaleString("$system_locale_js", {minimumFractionDigits: unit_rounding_array["windSpeed"], maximumFractionDigits: unit_rounding_array["windSpeed"]}) );
     }
+    
+    jQuery(".beaufort").html( beaufort_cat( parseFloat(data["beaufort_count"])) );
     
     // Wind Gust US
     // May not be provided in mqtt, but just in case.

--- a/skins/Belchertown/style.css
+++ b/skins/Belchertown/style.css
@@ -1502,7 +1502,7 @@ p.entry-meta {
     padding-right: 15px;
     /* margin: 0 -15px 0 -15px; */
     margin: 0 0 0 0;
-    width: 385px;
+    min-width: 275px;
 }
 
 .curwind {


### PR DESCRIPTION
1. Adds support for displaying the current Beaufort wind scale category underneath the wind speed. The category shows regardless of which unit system has been selected--you don't necessarily have to be displaying wind speed in Beaufort scale. 

https://user-images.githubusercontent.com/46248396/103393400-75915f80-4af0-11eb-85d6-b44bfd68f122.mov

Off by default. Enable by adding `beaufort_category = 1` to settings in weewx.conf. Users can supply their own translations for the 12 Beaufort scales like so. Default is English if nothing is specified.
```
[StdReport]
    [[Belchertown]]
        [[[Labels]]]
            [[[[Generic]]]]
                beaufort0 = calme
                beaufort1 = très légère brise
                beaufort2 = légère brise
                ...
                beaufort12 = ouragan
```

2. Forecast units now update automatically with whichever unit system has been selected globally. The `forecast_wind_units` option has been depreciated.



***IMPORTANT:*** Ensure that weewx is set to calculate Beaufort scale by adding the following to weewx.conf if not already there. This will insert a Beaufort scale reading into the MQTT payload. I don't really understand why that works--if someone could explain, I'd appreciate it.
```
[StdWXCalculate]
    [[Calculations]]
        beaufort = prefer_hardware
```

***ALSO IMPORTANT:*** if you want to change units, remember to change them for both weewx _and_ MQTT. Change units like so:
```
[StdReport]
    [[Defaults]]
        [[[Units]]]
            [[[[Groups]]]]
                group_speed = beaufort # or 'mile_per_hour', 'km_per_hour', 'knot', or 'meter_per_second'

[StdRESTful]
    [[MQTT]]
        [[[inputs]]]
            [[[[windSpeed]]]]
                name = windSpeed_beaufort # or ‘_mph’, ‘_kph’, ‘_knot’
                units = beaufort
```

*Changing units to Beaufort in weewx will throw errors due to a bug in weewx. The bug has been fixed but it won't be officially released until weewx 4.3. You can ignore the errors or install the latest development version of weewx.*