### PR TITLE
Fix for missing aeris icon showerswn

### DIFF
--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -868,6 +868,7 @@ class getData(SearchList):
                     "showers": "rain",
                     "showersn": "rain",
                     "showersw": "rain",
+                    "showerswn": "rain",
                     "sleet": "sleet",
                     "sleetn": "sleet",
                     "sleetsnow": "sleet",

--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -1078,7 +1078,7 @@ function aeris_icon( data ) {
         "showers": "rain",
         "showersn": "rain",
         "showersw": "rain",
-        "showersw": "rain",
+        "showerswn": "rain",
         "sleet": "sleet",
         "sleetn": "sleet",
         "sleetsnow": "sleet",


### PR DESCRIPTION
This is the fix following on from #462 to ensure a rain icon is displayed when aeris uses showerswn.