### PR TITLE
Fix for Aeris map dark mode switching

### DIFF
--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -516,31 +516,23 @@ function autoTheme(sunset_hour, sunset_min, sunrise_hour, sunrise_min) {
     belchertown_debug("Auto theme: are we in daylight hours: " + dayTime);
     belchertown_debug("Auto theme: sessionStorage.getItem('theme') = " + sessionStorage.getItem('theme'));
     
-    if ( dayTime ) {
+    if ( dayTime == true ) {
         // Day time, set light if needed
-        if ( document.body.classList.contains("dark") ) {
-            if ( sessionStorage.getItem('theme') == "auto" ) {
-                belchertown_debug("Auto theme: setting light theme since dayTime variable is true (day)");
-            } else {
-                belchertown_debug("Auto theme: cannot set light theme since visitor used toggle to override theme. Refresh to reset the override.");
-            }
-            // Only change theme if user has not overridden the auto option with the toggle
-            if ( sessionStorage.getItem('theme') == "auto" ) {
-                changeTheme("light");
-            }
+        // Only change theme if user has not overridden the auto option with the toggle
+        if ( sessionStorage.getItem('theme') == "auto" ) {
+            belchertown_debug("Auto theme: setting light theme since dayTime variable is true (day)");
+            changeTheme("light");
+        } else {
+            belchertown_debug("Auto theme: cannot set light theme since visitor used toggle to override theme. Refresh to reset the override.");
         }
     } else {
         // Night time, set dark if needed
-        if ( document.body.classList.contains("light") ) {
-            if ( sessionStorage.getItem('theme') == "auto" ) {
-                belchertown_debug("Auto theme: setting dark theme since dayTime variable is false (night)");
-            } else {
-                belchertown_debug("Auto theme: cannot set dark theme since visitor used toggle to override theme. Refresh to reset the override.");
-            }
-            // Only change theme if user has not overridden the auto option with the toggle
-            if ( sessionStorage.getItem('theme') == "auto" ) {
-                changeTheme("dark");
-            }
+        // Only change theme if user has not overridden the auto option with the toggle
+        if ( sessionStorage.getItem('theme') == "auto" ) {
+            belchertown_debug("Auto theme: setting dark theme since dayTime variable is false (night)");
+            changeTheme("dark");
+        } else {
+            belchertown_debug("Auto theme: cannot set dark theme since visitor used toggle to override theme. Refresh to reset the override.");
         }
     }
 }


### PR DESCRIPTION
This PR fixes a bug that made the light mode version of the Aeris map appear initially unless theme was automatically toggled during nighttime. In the process of fixing it I streamlined some code about theme switching; this seems to work exactly the same, but let me know if I’ve inadvertently broken something.