### PR TITLE
update disclaimer for bogus ConfigObj variable

### DIFF
--- a/install.py
+++ b/install.py
@@ -143,15 +143,14 @@ extension_config = """
 
            #-------------------------------------------------------------
            #---
-           #--- wee_extension in 4.3.0 needs at least one uncommented
-           #--- variable in the extension's install.py in order to
-           #--- write out an initially commented-out stanza for the
-           #--- newly installed skin
-           #---
+           #--- python's ConfigObj has a limitation in how it processes
+           #--- comments, so we need to define an 'unused' variable below
+           #--- to ensure that this whole stanza makes it into weewx.conf
+           #--- 
            #--- please ignore the following 'unused' variable
            #---
            #-------------------------------------------------------------
-           work_around_wee_extension_bugs = true
+           work_around_ConfigObj_limitations = true
 
 """
 config_dict = configobj.ConfigObj(StringIO(extension_config))


### PR DESCRIPTION
Tom clarified that the actual issue is a ConfigObj limitation, so I updated the disclaimer and slightly renamed the bogus variable I created as a (valid) workaround. If you want to have a fully-commented out Extras stanza you can simply delete the bogus variable and disclaimer, but if you ever want any of the example variable = value lines 'uncommented' then you'd need to still have the bogus variable at the bottom so all comments in-between make it into weewx.conf to work around ConfigObj's limitations.
