### PR TITLE
Install.py now defaults to Belchertown enabled=true

### DIFF
--- a/install.py
+++ b/install.py
@@ -46,7 +46,7 @@ extension_config = """
     [[Belchertown]]
         skin = Belchertown
         HTML_ROOT = belchertown
-        enable = false
+        enable = true 
 
         [[[Extras]]]
 


### PR DESCRIPTION
Small edit of #549–leaving `enabled = false` means that the skin gets disabled whenever someone uses wee_install to update it, so I changed it to `true` by default. Took me a while to figure out why my graphs had stopped updating.