### PR TITLE
belchertown.js.tmpl: Refactor precipitation handling

### DIFF
--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -1286,24 +1286,23 @@ function update_forecast_data( data ) {
                     windSpeed = data[(forecast_interval)][0]["response"][0]["periods"][i]["windSpeedMPH"];
                     windGust = data[(forecast_interval)][0]["response"][0]["periods"][i]["windGustMPH"];
                 }
-                
-                if ( ( data[(forecast_interval)][0]["response"][0]["periods"][i]["snowCM"] > 0 ) || ( data[(forecast_interval)][0]["response"][0]["periods"][i]["snowIN"] > 0 ) ) {
-                    // Determine snow unit
-                    if ( ( "$Extras.forecast_units" == "si" ) || ( "$Extras.forecast_units" == "ca" ) || ( "$Extras.forecast_units" == "uk2" ) ) {
-                        var snow_depth = data[(forecast_interval)][0]["response"][0]["periods"][i]["snowCM"];
-                        var snow_unit = "cm";
-                    } else {
-                        var snow_depth = data[(forecast_interval)][0]["response"][0]["periods"][i]["snowIN"];
-                        var snow_unit = "in";
-                    }
-                    precip = 0;
-               } else if ( data[(forecast_interval)][0]["response"][0]["periods"][i]["pop"] > 0 ) {
-                    // Rain percent of precip
-                    precip = data[(forecast_interval)][0]["response"][0]["periods"][i]["pop"];
+
+                /*
+                As per API specification, "pop" is either a number from 0 to
+                100 or null. We convert to 0 in the second case.
+                */
+                var precip = data[(forecast_interval)][0]["response"][0]["periods"][i]["pop"] || 0;
+
+                /*
+                Determine snow unit. "snowCM" and "snowIN" are specified
+                to always return a number.
+                */
+                if ( ( "$Extras.forecast_units" == "si" ) || ( "$Extras.forecast_units" == "ca" ) || ( "$Extras.forecast_units" == "uk2" ) ) {
+                    var snow_depth = data[(forecast_interval)][0]["response"][0]["periods"][i]["snowCM"];
+                    var snow_unit = "cm";
                 } else {
-                    precip = 0;
-                    snow_depth = 0;
-                    var snow_unit = "";
+                    var snow_depth = data[(forecast_interval)][0]["response"][0]["periods"][i]["snowIN"];
+                    var snow_unit = "in";
                 }
                 
                 //  for 24hr interval add 7200 (2 hours) to the epoch to get an hour well into the day to avoid any DST issues. This way it'll either be 1am or 2am. Without it, we get 12am or 11pm (the previous day).


### PR DESCRIPTION
This makes an attempt to simplify the precipitation handling by removing
unnecessary distinction of cases. Snow and rain are both precipitation
and thus pop will be > 0 in both cases. There is also no real reason to
check for snowCM > 0 or snowIM > 0 in the querying code as the displaying code will decide
whether snow or rain is shown depending on the value of snow_depth
anyway.

This also implicitly fixes a bug where all forecasts following one with
snow also showed snow with the same amount as snow_depth was not cleared
until a forecast with pop == 0 was reached.