### PR TITLE
Fix re match invocation

### DIFF
--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -1783,7 +1783,7 @@ class getData(SearchList):
                         eqplace = eqdata["features"][0]["properties"]["place"]
                     else:       # assume miles
                         try:
-                            eqmatched=re.match('(?P<distance>[0-9]*\.?[0-9]+) km(?P<rest>.*)$',
+                            eqmatched=match('(?P<distance>[0-9]*\.?[0-9]+) km(?P<rest>.*)$',
                                 eqdata["features"][0]["properties"]["place"])
                             eqdist_km = eqmatched.group('distance')
                             eqdist_miles = round(float(eqdist_km) / 1.609,1)


### PR DESCRIPTION
I'd accidentally been doing the re match using **re.match** instead of just **match**, which was failing because I'd done **from re import match** and the namespace wasn't there. This just removes the unneeded **re.** from that match. It was failing silently because it was in a try...except with the result being the distance was left as originally retrieved.