### PR TITLE
Additions to skin.conf

### DIFF
--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -1872,8 +1872,6 @@ class getData(SearchList):
                 obs_output = ""
             elif obs == "cloud_cover":
                 obs_output = cloud_cover
-                if label_dict["cloud_cover"] == "cloud_cover":
-                    label_dict["cloud_cover"] = "Cloud Cover"
             else:
                 obs_output = getattr(current, obs)
                 if "?" in str(obs_output):

--- a/skins/Belchertown/skin.conf
+++ b/skins/Belchertown/skin.conf
@@ -15,6 +15,8 @@
     logo_image = ""
     logo_image_dark = ""
     radar_html = ""
+    radar_html_dark = ""
+    aeris_map = 0
     almanac_extras = 1
 
     # Station Observations. Special observation rainWithRainRate combines Daily Rain with Rain Rate in 1 line
@@ -80,6 +82,13 @@
     forecast_show_daily_forecast_link = 0
     forecast_daily_forecast_link = ""
 
+    # Air Quality Index (AQI) defaults
+    aqi_enabled = 0
+    aqi_location_enabled = 0
+
+    # Beaufort wind scale defaults
+    beaufort_category = 0
+
     # Earthquake defaults
     earthquake_enabled = 0
     earthquake_maxradiuskm = 1000
@@ -114,6 +123,7 @@
         cloudbase            = Cloud Base
         visibility           = Visibility
         windrun              = Wind Run
+        cloud_cover          = Cloud Cover
 
         # HTML Header Meta Tags and HTML Title. These labels have a default value
         # set inside of header.html.tmpl. Leave as "" to use the default value.


### PR DESCRIPTION
Adds entries to skin.conf for AQI/Beaufort/weather map defaults, and adds label for cloud cover observation for translation purposes.