### PR TITLE
Earthquake distance and bearing in 2 lines

### DIFF
--- a/skins/Belchertown/index.html.tmpl
+++ b/skins/Belchertown/index.html.tmpl
@@ -554,7 +554,7 @@
                                     <i class="wi wi-earthquake"></i>$obs.label.earthquake_magnitude <span class="magnitude">$earthquake_magnitude</span>
                                 </div>
                                 <div class="col-sm-6 earthquake-distance-outer border-left">
-                                    <span class="earthquake-distance">$earthquake_distance_away $earthquake_distance_label $earthquake_bearing</span>
+                                    <span class="earthquake-distance">$earthquake_distance_away $earthquake_distance_label <br>$earthquake_bearing</span>
                                 </div>
                             </div>
                             #end if


### PR DESCRIPTION
To improve lisibility earthquake distance and bearing by forcing these 2 datas in 2 lines
In case of a short distance , information is displayed in 1 line

![earthquake](https://user-images.githubusercontent.com/65628453/108184970-11604480-710c-11eb-85c8-6eaae3ccf2d2.jpg)

