### PR TITLE
Use skin theme background when exporting Highcharts images

### DIFF
--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -1996,6 +1996,62 @@ function showChart(json_file, prepend_renderTo=false) {
                 },
                 
                 exporting: {
+					chartOptions: {
+						chart: {
+							events: {
+								load: function () {
+									this.title.update({style:{color: '#e5554e'}});
+
+									if ( sessionStorage.getItem('currentTheme') === 'dark' ) {
+										var darktheme_textcolor = '#fff';
+										for (var i = this.yAxis.length-1; i >= 0; i--) {
+											this.yAxis[i].update({
+												title:{style:{color: darktheme_textcolor}},												
+												labels:{style:{color: darktheme_textcolor}},
+												gridLineColor: '#707073',
+												tickColor: '#707073'
+											});
+										}
+										
+										for (var i = this.xAxis.length-1; i >= 0; i--) {
+											this.xAxis[i].update({
+												title:{style:{color: darktheme_textcolor}},
+												labels:{style:{color: darktheme_textcolor}},
+												gridLineColor: '#707073',
+												tickColor: '#707073'
+											});
+										}
+										
+										this.legend.update({itemStyle:{color: darktheme_textcolor}});
+									
+										//this.credits.update({style:{color: darktheme_textcolor}});
+
+										this.subtitle.update({style:{color: darktheme_textcolor}});
+									
+										this.chartBackground.attr({fill: jQuery( ".highcharts-background" ).css( "fill" )});
+									} else {
+										var lighttheme_textcolor = '#666666';
+										for (var i = this.yAxis.length-1; i >= 0; i--) {
+											this.yAxis[i].update({
+												title:{style:{color: lighttheme_textcolor}},
+												labels:{style:{color: lighttheme_textcolor}},
+											});
+										}
+										
+										for (var i = this.xAxis.length-1; i >= 0; i--) {
+											this.xAxis[i].update({
+												title:{style:{color: lighttheme_textcolor}},
+												labels:{style:{color: lighttheme_textcolor}},
+											});
+										}
+									}
+								}
+							}
+						}
+					},
+					// scale: 1,
+					// width: 1000,
+					// sourceWidth: 1000,
                     enabled: JSON.parse( String( exporting_enabled ) ) // Convert string to bool
                 },
 

--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -1996,62 +1996,62 @@ function showChart(json_file, prepend_renderTo=false) {
                 },
                 
                 exporting: {
-					chartOptions: {
-						chart: {
-							events: {
-								load: function () {
-									this.title.update({style:{color: '#e5554e'}});
+                    chartOptions: {
+                        chart: {
+                            events: {
+                                load: function () {
+                                    this.title.update({style:{color: '#e5554e'}});
 
-									if ( sessionStorage.getItem('currentTheme') === 'dark' ) {
-										var darktheme_textcolor = '#fff';
-										for (var i = this.yAxis.length-1; i >= 0; i--) {
-											this.yAxis[i].update({
-												title:{style:{color: darktheme_textcolor}},												
-												labels:{style:{color: darktheme_textcolor}},
-												gridLineColor: '#707073',
-												tickColor: '#707073'
-											});
-										}
+                                    if ( sessionStorage.getItem('currentTheme') === 'dark' ) {
+                                        var darktheme_textcolor = '#fff';
+                                        for (var i = this.yAxis.length-1; i >= 0; i--) {
+                                            this.yAxis[i].update({
+                                                title:{style:{color: darktheme_textcolor}},												
+                                                labels:{style:{color: darktheme_textcolor}},
+                                                gridLineColor: '#707073',
+                                                tickColor: '#707073'
+                                            });
+                                        }
 										
-										for (var i = this.xAxis.length-1; i >= 0; i--) {
-											this.xAxis[i].update({
-												title:{style:{color: darktheme_textcolor}},
-												labels:{style:{color: darktheme_textcolor}},
-												gridLineColor: '#707073',
-												tickColor: '#707073'
-											});
-										}
+                                        for (var i = this.xAxis.length-1; i >= 0; i--) {
+                                            this.xAxis[i].update({
+                                                title:{style:{color: darktheme_textcolor}},
+                                                labels:{style:{color: darktheme_textcolor}},
+                                                gridLineColor: '#707073',
+                                                tickColor: '#707073'
+                                            });
+                                        }
 										
-										this.legend.update({itemStyle:{color: darktheme_textcolor}});
+                                        this.legend.update({itemStyle:{color: darktheme_textcolor}});
 									
-										//this.credits.update({style:{color: darktheme_textcolor}});
+                                        //this.credits.update({style:{color: darktheme_textcolor}});
 
-										this.subtitle.update({style:{color: darktheme_textcolor}});
+                                        this.subtitle.update({style:{color: darktheme_textcolor}});
 									
-										this.chartBackground.attr({fill: jQuery( ".highcharts-background" ).css( "fill" )});
-									} else {
-										var lighttheme_textcolor = '#666666';
-										for (var i = this.yAxis.length-1; i >= 0; i--) {
-											this.yAxis[i].update({
-												title:{style:{color: lighttheme_textcolor}},
-												labels:{style:{color: lighttheme_textcolor}},
-											});
-										}
+                                        this.chartBackground.attr({fill: jQuery( ".highcharts-background" ).css( "fill" )});
+                                    } else {
+                                        var lighttheme_textcolor = '#666666';
+                                        for (var i = this.yAxis.length-1; i >= 0; i--) {
+                                            this.yAxis[i].update({
+                                                title:{style:{color: lighttheme_textcolor}},
+                                                labels:{style:{color: lighttheme_textcolor}},
+                                            });
+                                        }
 										
-										for (var i = this.xAxis.length-1; i >= 0; i--) {
-											this.xAxis[i].update({
-												title:{style:{color: lighttheme_textcolor}},
-												labels:{style:{color: lighttheme_textcolor}},
-											});
-										}
-									}
-								}
-							}
-						}
-					},
-					// scale: 1,
-					// width: 1000,
-					// sourceWidth: 1000,
+                                        for (var i = this.xAxis.length-1; i >= 0; i--) {
+                                            this.xAxis[i].update({
+                                                title:{style:{color: lighttheme_textcolor}},
+                                                labels:{style:{color: lighttheme_textcolor}},
+                                            });
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    // scale: 1,
+                    // width: 1000,
+                    // sourceWidth: 1000,
                     enabled: JSON.parse( String( exporting_enabled ) ) // Convert string to bool
                 },
 


### PR DESCRIPTION
Apply light or dark background when exporting Highcharts images. Previously discussed in (closed) #402.

Three commented out options in the source give the user the opportunity to change the size of the images to its preferences
(maybe at some point this should move to graphs.conf?):

                    // scale: 1,
                    // width: 1000,
                    // sourceWidth: 1000,

Examples of light versus dark:

![temperatuur (light)](https://user-images.githubusercontent.com/67259651/108601475-0ff97b00-739d-11eb-9e28-a21f61836871.png)

![temperatuur (dark)](https://user-images.githubusercontent.com/67259651/108601478-1556c580-739d-11eb-9697-3e7402073295.png)

![windsnelheid-en-richting (light)](https://user-images.githubusercontent.com/67259651/108601481-1ab41000-739d-11eb-885d-4c7c3a6fafa8.png)

![windsnelheid-en-richting (dark)](https://user-images.githubusercontent.com/67259651/108601484-1f78c400-739d-11eb-8e1a-7860ff710bd1.png)

![windroos (light)](https://user-images.githubusercontent.com/67259651/108601490-23a4e180-739d-11eb-8eda-c52761ed720c.png)

![windroos (dark)](https://user-images.githubusercontent.com/67259651/108601493-28699580-739d-11eb-8601-7a1d40286708.png)
