### PR TITLE
Change NOAA default report encoding to utf-8

### DIFF
--- a/skins/Belchertown/skin.conf
+++ b/skins/Belchertown/skin.conf
@@ -758,13 +758,13 @@
     [[SummaryByMonth]]
         # Reports that summarize "by month"
         [[[NOAA_month]]]
-            encoding = strict_ascii
+            encoding = utf8
             template = NOAA/NOAA-YYYY-MM.txt.tmpl
 
     [[SummaryByYear]]
         # Reports that summarize "by year"
         [[[NOAA_year]]]
-            encoding = strict_ascii
+            encoding = utf8
             template = NOAA/NOAA-YYYY.txt.tmpl
 
     [[ToDate]]


### PR DESCRIPTION
As mentioned in issue #587