### PR TITLE
Improved selection of moon icons (#234 and #328)

### DIFF
--- a/skins/Belchertown/index.html.tmpl
+++ b/skins/Belchertown/index.html.tmpl
@@ -360,23 +360,7 @@
                                                 <div class="col-sm-7 moon">
                                                     <div class="moon-container">
                                                         <span class="moon-icon">
-                                                            #if $almanac.moon_index == 0
-                                                                <div class='wi wi-moon-alt-new'></div>
-                                                            #else if $almanac.moon_index == 1
-                                                                <div class='wi wi-moon-alt-waxing-crescent-1 $hemisphere'></div>
-                                                            #else if $almanac.moon_index == 2
-                                                                <div class='wi wi-moon-alt-first-quarter $hemisphere'></div>
-                                                            #else if $almanac.moon_index == 3
-                                                                <div class='wi wi-moon-alt-waxing-gibbous-3 $hemisphere'></div>
-                                                            #else if $almanac.moon_index == 4
-                                                                <div class='wi wi-moon-alt-full'></div>
-                                                            #else if $almanac.moon_index == 5
-                                                                <div class='wi wi-moon-alt-waning-gibbous-3 $hemisphere'></div>
-                                                            #else if $almanac.moon_index == 6
-                                                                <div class='wi wi-moon-alt-first-quarter $hemisphere'></div>
-                                                            #else if $almanac.moon_index == 7
-                                                                <div class='wi wi-moon-alt-waning-crescent-4 $hemisphere'></div>
-                                                            #end if
+                                                            <div class="moon-icon"></div><!-- JS -->
                                                         </span>
                                                         <strong><span class="moon-phase">#echo $almanac.moon_phase.title()#</span></strong><!-- AJAX -->
                                                         <br>

--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -654,32 +654,7 @@ function update_weewx_data(data) {
     jQuery(".sunset-value").html(moment.unix(parseFloat(data["almanac"]["sunset_epoch"]).toFixed(0)).utcOffset($moment_js_utc_offset).format("$obs.label.time_sunset"));
 
     // Moon icon, phase and illumination percent
-    switch (data["almanac"]["moon"]["moon_index"]) {
-        case "0":
-            jQuery(".moon-icon").html("<div class='wi wi-moon-alt-new'></div>");
-            break;
-        case "1":
-            jQuery(".moon-icon").html("<div class='wi wi-moon-alt-waxing-crescent-3 $hemisphere'></div>");
-            break;
-        case "2":
-            jQuery(".moon-icon").html("<div class='wi wi-moon-alt-first-quarter $hemisphere'></div>");
-            break;
-        case "3":
-            jQuery(".moon-icon").html("<div class='wi wi-moon-alt-waxing-gibbous-3 $hemisphere'></div>");
-            break;
-        case "4":
-            jQuery(".moon-icon").html("<div class='wi wi-moon-alt-full'></div>");
-            break;
-        case "5":
-            jQuery(".moon-icon").html("<div class='wi wi-moon-alt-waning-gibbous-3 $hemisphere'></div>");
-            break;
-        case "6":
-            jQuery(".moon-icon").html("<div class='wi wi-moon-alt-third-quarter $hemisphere'></div>");
-            break;
-        case "7":
-            jQuery(".moon-icon").html("<div class='wi wi-moon-alt-waning-crescent-4 $hemisphere'></div>");
-            break;
-    }
+    jQuery(".moon-icon").html(moon_icon(data["almanac"]["moon"]["moon_index"]));        
     jQuery(".moon-phase").html(titleCase(data["almanac"]["moon"]["moon_phase"])); // Javascript function above
     jQuery(".moon-visible").html("<strong>" + data["almanac"]["moon"]["moon_fullness"] + "%</strong> $obs.label.moon_visible");
     #if $almanac.hasExtras
@@ -689,6 +664,28 @@ function update_weewx_data(data) {
     almanac_updated = "$obs.label.header_last_updated " + moment.unix(data["current"]["datetime_raw"]).utcOffset($moment_js_utc_offset).format("$obs.label.time_last_updated");
     jQuery(".almanac_last_updated").html(almanac_updated);
     #end if
+}
+
+//  function returns html for moon-icon according to moonphase value and currentTheme setting
+function moon_icon(moonphase){
+    
+    var moon_icon_dict = {
+        "0": "<div class='wi wi-moon-new'></div>",
+        "1": "<div class='wi wi-moon-waxing-crescent-3 $hemisphere'></div>",
+        "2": "<div class='wi wi-moon-first-quarter $hemisphere'></div>",
+        "3": "<div class='wi wi-moon-waxing-gibbous-3 $hemisphere'></div>",
+        "4": "<div class='wi wi-moon-full'></div>",
+        "5": "<div class='wi wi-moon-waning-gibbous-3 $hemisphere'></div>",
+        "6": "<div class='wi wi-moon-third-quarter $hemisphere'></div>",
+        "7": "<div class='wi wi-moon-waning-crescent-4 $hemisphere'></div>",
+    }
+    
+    var output = moon_icon_dict[moonphase];
+    if (sessionStorage.getItem('currentTheme') === 'dark') {
+        return output;
+    } else {
+        return output.replace('-moon-','-moon-alt-');
+    }
 }
 
 #if $Extras.has_key("forecast_enabled") and $Extras.forecast_enabled == '1'


### PR DESCRIPTION
This PR attempts to resolve the issues raised in #234 and #238.
The changes simplify the handling of the moon icons and enables the type of moon icon to be selected automatically according to the value of currentTheme ('light' or 'dark').  This means that those who normally us the dark theme will see the moon as it appears against a dark background in the sky.  Those who use the light mode should see no difference.  The type of moon icon is selected on each archive interval ,so there will be a small delay in seeing the correct icon when you switch from light to dark or vice versa, unless you refresh the browser.  