### PR TITLE
Add MQTT WS authentication support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ For ease of readability I have broken them out into separate tables. However you
 | mqtt_websockets_port | 8080 | The port of the MQTT broker's **Websockets** port. Check your broker's documentation. **Versions 0.8.2 and prior** this option is called `mqtt_port`
 | mqtt_websockets_ssl | 0 | Set to 1 if your broker is using SSL. **Versions 0.8.2 and prior** this option is called `mqtt_ssl`
 | mqtt_websockets_topic | "" | The topic to subscribe to for your weather data. Typically this should end in `/loop`. (e.g. `weather/loop`) depending on your [MQTT] extension settings.  **Versions 0.8.2 and prior** this option is called `mqtt_topic`
+| mqtt_websockets_user | "" | Username for authentication with your MQTT broker
+| mqtt_websockets_pass | "" | Password for authentication with your MQTT broker
 | disconnect_live_website_visitor | 1800000 | The number of seconds after a visitor has loaded your page that we disconnect them from the live streaming updates. The idea here is to save your broker from a streaming connection that never ends. Time is in milliseconds. 0 = disabled. 300000 = 5 minutes. 1800000 = 30 minutes
 
 

--- a/changelog
+++ b/changelog
@@ -3,6 +3,7 @@
 * New AerisWeather forecast display options for Belchertown skin will require you to delete your forecast.json file so that the skin can generate a new one.
 
 ### Added
+* Support for MQTT websocket username and password
 
 ### Changed
 

--- a/install.py
+++ b/install.py
@@ -105,6 +105,8 @@ extension_config = """
            # mqtt_websockets_port = 8080
            # mqtt_websockets_ssl	= 0
            # mqtt_websockets_topic = ""
+           # mqtt_websockets_user = ""
+           # mqtt_websockets_pass = ""
            # disconnect_live_website_visitor = 1800000
 
            #--- Forecast Options ---

--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -1605,6 +1605,12 @@ function connect() {
     client.onConnectionLost = onConnectionLost;
     client.onMessageArrived = onMessageArrived;
     var options = {
+        #if $Extras.has_key("mqtt_websockets_user") and $Extras.mqtt_websockets_user != ""
+        userName: "$Extras.mqtt_websockets_user",
+        #end if
+        #if $Extras.has_key("mqtt_websockets_pass") and $Extras.mqtt_websockets_pass != ""
+        password: "$Extras.mqtt_websockets_pass",
+        #end if
         #if $Extras.has_key("mqtt_websockets_ssl") and $Extras.mqtt_websockets_ssl == '1'
         useSSL: true,
         #else

--- a/skins/Belchertown/skin.conf
+++ b/skins/Belchertown/skin.conf
@@ -42,6 +42,8 @@
     mqtt_websockets_port = 1883
     mqtt_websockets_ssl = 0
     mqtt_websockets_topic = ""
+    mqtt_websockets_user = ""
+    mqtt_websockets_pass = ""
     disconnect_live_website_visitor = 1800000
 
     # Show an alert if the page updated timestamp is older than expected with this setting. Does not apply to MQTT Websocket enabled websites


### PR DESCRIPTION
This change adds support for MQTT websocket authentication via a
username and password. New configuration items have been added, but this
should also be backwards compatible with older configs:
* mqtt_websockets_user
* mqtt_websockets_pass

Signed-off-by: Michael Bergeron <mikeb.code@gmail.com>