### PR TITLE
Add xAxis labels formatter

### DIFF
--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -2377,6 +2377,12 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
                 connectNulls = plot_options.get("connectNulls", "false")
                 output[chart_group][plotname]["options"]["connectNulls"] = connectNulls
 
+                # xAxis labels formatter
+                xAxis_labels_formatter = plot_options.get("xAxis_labels_formatter", "")
+                output[chart_group][plotname]["options"][
+                    "xAxis_labels_formatter"
+                ] = xAxis_labels_formatter
+
                 xAxis_groupby = plot_options.get("xAxis_groupby", None)
                 xAxis_categories = plot_options.get("xAxis_categories", "")
                 # Check if this is a list. If not then we have 1 item, so force
@@ -2783,6 +2789,7 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
                         time_length,
                         xAxis_groupby,
                         xAxis_categories,
+                        xAxis_labels_formatter,
                         mirrored_value,
                         weatherRange_obs_lookup,
                         wind_rose_color,
@@ -2851,6 +2858,7 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
         time_length,
         xAxis_groupby,
         xAxis_categories,
+        xAxis_labels_formatter,
         mirrored_value,
         weatherRange_obs_lookup,
         wind_rose_color,

--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -1991,6 +1991,9 @@ function showChart(json_file, prepend_renderTo = false) {
                     case "rounding":
                         rounding = optionVal;
                         break;
+                    case "xAxis_labels_formatter":
+                        xAxis_labels_formatter = optionVal;
+                        break;
                     case "xAxis_categories":
                         xAxis_categories = optionVal;
                         break;
@@ -2264,6 +2267,17 @@ function showChart(json_file, prepend_renderTo = false) {
                 options.plotOptions.series = {connectNulls: connectNulls};
             }
             options.colors = colors;
+
+            // xAxis labels formatter
+            if (xAxis_labels_formatter.length >= 1) {
+                options.xAxis = {
+                    labels: {
+                        formatter: function() {
+                            return Highcharts.dateFormat(xAxis_labels_formatter, this.value);
+                        }
+                    }
+                }
+            }
 
             // If we have xAxis categories, reset xAxis and populate it from these options. Also need to reset tooltip since there's no datetime for moment.js to use.
             if (xAxis_categories.length >= 1) {


### PR DESCRIPTION
That will allow users to format `xAxis` labels with Highcharts:
```
%a: Short weekday, like 'Mon'.
%A: Long weekday, like 'Monday'.
%d: Two digit day of the month, 01 to 31.
%e: Day of the month, 1 through 31.
%b: Short month, like 'Jan'.
%B: Long month, like 'January'.
%m: Two digit month number, 01 through 12.
%y: Two digits year, like 21 for 2021.
%Y: Four digits year, like 2021.
%H: Two digits hours in 24h format, 00 through 23.
%I: Two digits hours in 12h format, 00 through 11.
%l (Lower case L): Hours in 12h format, 1 through 11.
%M: Two digits minutes, 00 through 59.
%p: Upper case AM or PM.
%P: Lower case AM or PM.
%S: Two digits seconds, 00 through 59
```
for example 
```
    [[temp]]
        title = Outside temperature
        xAxis_labels_formatter = %a
        [[[outTemp]]]
            name = Out temp.

```
will show short weekday on xAxis.
![Screenshot_2021-03-21 Météo Correns - Station météorologique en temps réel](https://user-images.githubusercontent.com/12499787/111898149-7b7a4b00-8a24-11eb-8cf7-63a620aa8b56.png)