### PR TITLE
Ability to display the average of max, min or sum aggregate values

### DIFF
--- a/skins/Belchertown/graphs.conf
+++ b/skins/Belchertown/graphs.conf
@@ -1,0 +1,50 @@
+
+[OverallSummary]
+	# Overall Summary across all years
+    # Uses special observation_types maxTemp & minTemp to get their average, if aggregate_interval = 86400 only
+	
+    aggregate_interval = 86400  #86400 # 1 day
+    button_text = "All Years"
+    gapsize = 86400
+    #   suppressed for testing  generate = monthly
+    show_button = true
+	time_length = all
+    title = "Summary for all years"
+    type = spline
+    xAxis_categories = 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+    xAxis_groupby = month
+
+    [[RainTemperatureAll]]
+        title = "Rainfall & Average (max/min) Temperature"
+        subtitle = "for all months in all years"
+        [[[outTemp_max_All]]]
+            aggregate_type = avg
+            color = "#fc0404"
+            name = Max Temperature
+            observation_type = maxTemp
+			yAxis_label = Temperature (°C)
+            yAxis_max = 30
+            yAxis_min = -10
+            zIndex = 2
+            [[[[marker]]]]
+                enabled = true
+                radius = 4
+        [[[outTemp_min_All]]]
+            aggregate_type = avg
+            color = "#90ed7d"	# was "#173c6a"
+            name = Min Temperature
+            observation_type = minTemp
+            yAxis_max = 30
+            yAxis_min = -10
+            zIndex = 2
+            [[[[marker]]]]
+                enabled = true
+                radius = 4
+        [[[rainTotal_All]]]
+            aggregate_type = avg
+            color = "#438bd6"		
+            name = Rain Total
+            observation_type = rainTotal
+            type = column
+            yAxis = 1
+            zIndex = 0


### PR DESCRIPTION
This PR introduces a new chart setting average_type that enables the average of maximum , minimum or sum values over the following xAxis_groupby settings: hour, day, month, year.  It can take one of four values: None, max, min or sum.
It is particularly useful for displaying such things as average monthly rainfall per month for all years.

Example use to display average monthly rainfall
xAxis_groupby = month
aggregate_type = avg
average_type = sum
It does not matter whether you use rain or rainTotal

Results to be seen at http://lordshipweather.uk/graphs/?graph=summary

Two points to note
1. It incorporates the changes made in #649
2. I have tested it with sqlite, but as before would appreciate it being  tested by someone using mysql.

Once it has been merged, I will produce some text for the charts wiki.