### PR TITLE
Fix for tooltip to display rounding correctly

### DIFF
--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -2283,7 +2283,8 @@ function showChart(json_file, prepend_renderTo = false) {
                                 var point_obsType = point.series.userOptions.observation_type ? point.series.userOptions.observation_type : point.series.userOptions.obsType;
                                 var rounding = point.series.userOptions.rounding;
                                 var mirrored = point.series.userOptions.mirrored_value;
-                                return "<span style='color:" + point.series.color + "'>\u25CF</span> " + point.series.name + ': ' + highcharts_tooltip_factory(point.y, point_obsType, true, rounding, mirrored);
+                                var numberFormat = point.series.userOptions.numberFormat ? point.series.userOptions.numberFormat : "";
+                                return "<span style='color:" + point.series.color + "'>\u25CF</span> " + point.series.name + ': ' + highcharts_tooltip_factory(point.y, point_obsType, true, rounding, mirrored, numberFormat);
                             })
                         );
                     },


### PR DESCRIPTION
Hello

This is the fix for #626.  Running some debug in the highcharts_tooltip_factory function call, I worked out it was always falling to the catch (err), in a lot of cases.  This was because numberFormat was not being passed through on one of the calls.  This means it was displaying the data value

```
// Fall back to just returning the highcharts point number value, which is a best guess.
            output = Highcharts.numberFormat(obsvalue);
```

This fix does mean that numberFormat is being observered.

```
        [[[outTemp_min]]]
            name = Min Temperature
            observation_type = outTemp
            aggregate_type = min
            zIndex = 2
            [[[[numberFormat]]]]
                decimals = 6
```

![image](https://user-images.githubusercontent.com/59254774/113474051-4b3f9d00-9465-11eb-9825-bb8910aced37.png)

Note.  This does mean a lot of tooltips will change as a result of this, because it is now correctly trying to use the rounding from StringFormats where set.   I can't see how the -1 code option is being set though if no rounding data, because I was never seeing -1 in my debug only 0.

```
            belchertown_debug("highcharts_tooltip_factory: " + moment.unix(epoch).utcOffset($moment_js_utc_offset).format() + ": obsvalue: " + obsvalue + ", rounding: " + rounding + ", decimals: " + decimals);

            // Try to apply the highcharts numberFormat for locale awareness. Use rounding from weewx.conf StringFormats.
            // -1 is set from Python to notate no rounding data available and decimals from graphs.conf is undefined.
            if (rounding == "-1" && typeof decimals === "undefined") {
                output = Highcharts.numberFormat(obsvalue);
```

![image](https://user-images.githubusercontent.com/59254774/113474829-36b1d380-946a-11eb-9728-760550bb61bc.png)
