### PR TITLE
Uppercase first letter of snapshots dates

### DIFF
--- a/skins/Belchertown/style.css
+++ b/skins/Belchertown/style.css
@@ -1865,6 +1865,10 @@ table.celestial td.label {
     font-size:20px;
 }
 
+.stats-title::first-letter {
+    text-transform: uppercase;
+}
+
 .magnitude {
 	/* font-size:23px; */
 }


### PR DESCRIPTION
The date in snapshot table header is in low case in latin language.
![Screenshot_2021-04-09 Météo Correns - Station météorologique en temps réel](https://user-images.githubusercontent.com/12499787/114129343-adcde880-98fe-11eb-9144-b6d3429153cf.png)
![Screenshot_2021-04-09 Condiciones actuales del clima para Colegiales - CABA - Argentina](https://user-images.githubusercontent.com/12499787/114129350-b1616f80-98fe-11eb-8dd5-5744f06eec78.png)
after applying the new css:
![Screenshot_2021-04-09 Météo Correns - Station météorologique en temps réel(1)](https://user-images.githubusercontent.com/12499787/114129528-000f0980-98ff-11eb-8139-31e1ecde1db5.png)
