### PR TITLE
Add future data points with a null value

### DIFF
--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -3362,7 +3362,7 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
                     "Error was: %s." % (binding, obs_lookup, e)
                 )
 
-            self.insert_null_value_timestamps_to_end_ts(time_start_vt, time_stop_vt, obs_vt, end_ts, aggregate_interval)
+            self.insert_null_value_timestamps_to_end_ts(time_start_vt, time_stop_vt, obs_vt, start_ts, end_ts, aggregate_interval)
             
             min_obs_vt = self.converter.convert(obs_vt)
 
@@ -3381,7 +3381,7 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
                     "Error was: %s." % (binding, obs_lookup, e)
                 )
 
-            self.insert_null_value_timestamps_to_end_ts(time_start_vt, time_stop_vt, obs_vt, end_ts, aggregate_interval)
+            self.insert_null_value_timestamps_to_end_ts(time_start_vt, time_stop_vt, obs_vt, start_ts, end_ts, aggregate_interval)
             
             max_obs_vt = self.converter.convert(obs_vt)
 
@@ -3594,7 +3594,7 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
                 % (binding, obs_lookup, e)
             )
 
-        self.insert_null_value_timestamps_to_end_ts(time_start_vt, time_stop_vt, obs_vt, end_ts, aggregate_interval)
+        self.insert_null_value_timestamps_to_end_ts(time_start_vt, time_stop_vt, obs_vt, start_ts, end_ts, aggregate_interval)
         
         obs_vt = self.converter.convert(obs_vt)
 
@@ -3657,7 +3657,7 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
 
         return data
 
-    def insert_null_value_timestamps_to_end_ts(self, time_start_vt, time_stop_vt, obs_vt, end_ts, interval):
+    def insert_null_value_timestamps_to_end_ts(self, time_start_vt, time_stop_vt, obs_vt, start_ts, end_ts, interval):
         """
         In weewx 4.5.1 xtypes.py was modified to not return any data points which didn't exist in the archive database.
         This function adds the 'future' data points from the last timestamp in the list up until end_ts with None entries.
@@ -3665,10 +3665,11 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
         """
         count = 0
 
-        last_ts = time_start_vt[0][-1]
-
         if interval is not None:
-            ts = last_ts + interval
+            try:
+                ts = time_start_vt[0][-1] + interval
+            except:
+                ts = start_ts
 
             while ts < end_ts:
                 time_start_vt[0].append(ts)

--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -3362,6 +3362,8 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
                     "Error was: %s." % (binding, obs_lookup, e)
                 )
 
+            self.insert_null_value_timestamps_to_end_ts(time_start_vt, time_stop_vt, obs_vt, end_ts, aggregate_interval)
+            
             min_obs_vt = self.converter.convert(obs_vt)
 
             # Get max values
@@ -3379,6 +3381,8 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
                     "Error was: %s." % (binding, obs_lookup, e)
                 )
 
+            self.insert_null_value_timestamps_to_end_ts(time_start_vt, time_stop_vt, obs_vt, end_ts, aggregate_interval)
+            
             max_obs_vt = self.converter.convert(obs_vt)
 
             obs_unit = max_obs_vt[1]
@@ -3590,6 +3594,8 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
                 % (binding, obs_lookup, e)
             )
 
+        self.insert_null_value_timestamps_to_end_ts(time_start_vt, time_stop_vt, obs_vt, end_ts, aggregate_interval)
+        
         obs_vt = self.converter.convert(obs_vt)
 
         # Special handling for the rain.
@@ -3650,6 +3656,28 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
         data = zip(time_ms, obs_round_vt)
 
         return data
+
+    def insert_null_value_timestamps_to_end_ts(self, time_start_vt, time_stop_vt, obs_vt, end_ts, interval):
+        """
+        In weewx 4.5.1 xtypes.py was modified to not return any data points which didn't exist in the archive database.
+        This function adds the 'future' data points from the last timestamp in the list up until end_ts with None entries.
+        This means that graphs still have the option of showing a full day or month or year on the x axis depending on the time_length specfied.       
+        """
+        count = 0
+
+        last_ts = time_start_vt[0][-1]
+
+        if interval is not None:
+            ts = last_ts + interval
+
+            while ts < end_ts:
+                time_start_vt[0].append(ts)
+                time_stop_vt[0].append(ts)
+                ts = ts + interval
+                count = count + 1
+
+        for i in range(count):
+           obs_vt[0].append(None)
 
     def round_none(self, value, places):
         """Round value to 'places' places but also permit a value of None"""


### PR DESCRIPTION
As discussed in #695 weewx 4.5.1 xtypes.py was modified to not return any data points which didn't exist in the archive database (ie those in the future).

This pull request restores the previous functionality to graphs by inserting any data points from the future with a None (python) / null (highcharts) value for the time_length being specified for the graph.

I am open to advice on if this is the best coding style as I am still pretty new to coding in python.