### PR TITLE
Improve formatting of highchart graph json output

### DIFF
--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -2832,12 +2832,12 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
 
             # Write the output to the JSON file
             with open(json_filename, mode="w") as jf:
-                jf.write(json.dumps(output[chart_group]))
+                jf.write(json.dumps(output[chart_group], indent=4))
 
             # Save the graphs.conf to a json file for future debugging
             chart_json_filename = html_dest_dir + "/graphs.json"
             with open(chart_json_filename, mode="w") as cjf:
-                cjf.write(json.dumps(self.chart_dict))
+                cjf.write(json.dumps(self.chart_dict, indent=4))
 
     def get_observation_data(
         self,


### PR DESCRIPTION
Rather than having the json files all outputted as single lines, making it hard to read, this adds CRs and indents to json files for PD/debug purposes.

Here is an example now it has the indent=4 option set.

```
/var/www/html/weewx/json# more day.json
{
    "belchertown_version": "1.3b1",
    "generated_timestamp": "06/27/2021 19:35:18",
    "colors": "#7cb5ec, #b2df8a, #f7a35c, #8c6bb1, #dd3497, #e4d354, #268bd2, #f45b5b, #6a3d9a, #33a02c",
    "chartgroup_title": "Today since Midnight",
    "tooltip_date_format": "LLL",
    "credits": "highcharts_default",
    "credits_url": "highcharts_default",
    "credits_position": "highcharts_default",
    "dayTemp": {
        "series": {
            "outTemp": {
                "obsType": "outTemp",
                "yAxis_label": "Temperature (\u00b0C)",
                "polar": "false",
                "zIndex": 1.0,
                "name": "Temperature",
                "rounding": 1.0,
                "data": [
                    [
                        1624748700000.0,
                        14.6
                    ],
                    [
                        1624749000000.0,
                        14.4
                    ],
...
```