### PR TITLE
Add missing aeris-icon-list file to extension installer

### DIFF
--- a/install.py
+++ b/install.py
@@ -226,7 +226,8 @@ files=[('bin/user', ['bin/user/belchertown.py'
                                      'skins/Belchertown/images/unknown.png',
                                      'skins/Belchertown/images/wind.png',
                                      'skins/Belchertown/images/windy.png',
-                                     'skins/Belchertown/images/index.html'
+                                     'skins/Belchertown/images/index.html',
+                                     'skins/Belchertown/images/aeris-icon-list.json'                                    
                                     ]
         )
 ]


### PR DESCRIPTION
The file was in the distro, it was just missing from the installer.