### PR TITLE
changed calculation of point_timestamp

### DIFF
--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -3736,7 +3736,8 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
         try:
             if not aggregate_type:
                 point_timestamp = time_stop_vt
-            elif aggregate_interval and aggregate_interval == 3600:
+            elif aggregate_interval and (
+                      aggregate_interval == 3600 or aggregate_interval==2629800):
                 point_timestamp = time_start_vt
             else:
                 point_timestamp = ([(x+y)/2.0 for x,y in zip(time_start_vt[0],time_stop_vt[0])],time_start_vt[1],time_start_vt[2])

--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -3733,14 +3733,15 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
         # previous minute in the tooltip. (e.g. 4:59 instead of 5:00)
         # Everything else has it on the start time so we don't see the next day
         # in the tooltip (e.g. Jan 2 instead of Jan 1)
-        if (
-            time_length == "today"
-            or time_length == "timespan_specific"
-            or isinstance(time_length, int)
-        ):
+        try:
+            if not aggregate_type:
+                point_timestamp = time_stop_vt
+            elif aggregate_interval and aggregate_interval == 3600:
+                point_timestamp = time_start_vt
+            else:
+                point_timestamp = ([(x+y)/2.0 for x,y in zip(time_start_vt[0],time_stop_vt[0])],time_start_vt[1],time_start_vt[2])
+        except Exception:
             point_timestamp = time_stop_vt
-        else:
-            point_timestamp = time_start_vt
 
         # If the values are to be mirrored, we need to make them negative
         if mirrored_value:


### PR DESCRIPTION
See #726 

Graphs with aggregation often show a timestamp in future because the end timestamp of the aggregation timespan is used for point_timestamp. That is especially a problem if the timespan ends at a day boundary. This PR tries to implement a more appropriate determination of point_timestamp.

