### PR TITLE
had two twitter_owner lines in install.py

### DIFF
--- a/install.py
+++ b/install.py
@@ -134,7 +134,6 @@ extension_config = """
            #--- Social Options ---
            # facebook_enabled = 0
            # twitter_enabled = 0
-           # twitter_owner = ""
            # twitter_hashtags = "weewx #weather"
            # social_share_html = ""
            # twitter_text = "Check out my website: My Weather Website Weather Conditions"


### PR DESCRIPTION
I noticed today that when I sent you PR 549 last winter that I had two twitter_owner lines in the items install.py will write out as commented-out lines into weewx.conf - this PR just removes the extra one.