### PR TITLE
Added mqttVersion to Paho client options

### DIFF
--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -1522,6 +1522,7 @@ function connect() {
         userName:"$Extras.mqtt_websockets_username",
         password:"$Extras.mqtt_websockets_password",
         #end if
+        mqttVersion: 3,
         reconnect: true,
         onSuccess: onConnect,
         onFailure: onFailure


### PR DESCRIPTION
Solved an error in my station where the theme can't connect to my MQTTs WebSocket.