### PR TITLE
added chart option "unit" for special target units

### DIFF
--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -2587,7 +2587,7 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
                             continue
                             
                     # use different target unit
-                    special_target_unit = line_options.get("units",None)
+                    special_target_unit = line_options.get("unit",None)
 
                     # Get the unit label
                     if observation_type == "rainTotal":


### PR DESCRIPTION
I missed an option to set the target unit for an observation type in `graphs.conf`. So I would like to introduce a new option `units` that allows to set the unit individually for each chart. That comes in useful if you want to show graphs for summarized readings with an unit starting with "kilo" or "mega" for long time periods (month, year), but use the base unit for short time periods (day, week, may be). Using that option converts the values of the chart line it is specified for to the given target unit and sets the unit label appropriately. I hope that will be useful to other users, too.

Typical units for that would be `watt_hour` and `kilowatt_hour` or `watt_hour_per_meter_squared` and `kilowatt_hour_per_meter_squared`, respectively.

Example:
```
    [[sun]]
        ...
        aggregate_interval = 86400
        start_at_midnight = true
        [[[radiation]]]
            aggregate_type = energy_integral
            units = kilowatt_hour_per_meter_squared
```
