### PR TITLE
Added error handling when querying StringFormats

### DIFF
--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -3723,9 +3723,17 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
                     round(x, usage_round) if x is not None else None for x in obs_vt[0]
                 ]
             else:
-                usage_round = int(
-                    self.skin_dict["Units"]["StringFormats"].get(obs_vt[1], "2f")[-2]
-                )
+                try:
+                   usage_round = int(
+                       self.skin_dict["Units"]["StringFormats"].get(obs_vt[1], "2f")[-2]
+                   )
+                except ValueError:
+                   loginf (
+                      "Observation %s is using unit %s that returns %s for StringFormat, rather than float point decimal format value - using 0 as rounding"
+                      % (observation, obs_vt[1], self.skin_dict["Units"]["StringFormats"].get(obs_vt[1]))
+                   )
+                   usage_round = 0
+
                 obs_round_vt = [self.round_none(x, usage_round) for x in obs_vt[0]]
 
         # "Today" charts, "timespan_specific" charts and floating timespan


### PR DESCRIPTION
This is a fix for #761 and #774 to add error handling when trying to look-up StringFormats for an observation to ascertain rounding for graphs where the unit exists but isn't in the standard format of %.1f as an example.

The key example is lighting_strike_count where count is not defined in the belchertown skin.conf so it uses the default of %d from bin/weewx/defaults.py

It will log to system syslog as follows
`Mar 31 16:00:25 pi weewx[8829] INFO user.belchertown: Observation lightning_strike_count is using unit count that returns %d for StringFormat, rather than float point decimal format value - using 0 as rounding`

This message can then be cleared by the user adding count to StringFormats

```
    [[StringFormats]]
        # This section sets the string formatting for each type of unit.
...
        watt_per_meter_squared = %.0f
        count              = %.0f
        NONE               = "N/A"
```

This is only been an issue since weewx has changed the underlying code since weewx 4.6.0 onwards.