### PR TITLE
Fix MQTT connection logic

### DIFF
--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -1574,7 +1574,12 @@ function connect() {
         userName:"$Extras.mqtt_websockets_username",
         password:"$Extras.mqtt_websockets_password",
         #end if
-        mqttVersion: 3,
+        // mqttVersion: 4 is spec MQTTv3.1.1 - mqttVersion: 3 is spec MQTTv3.1
+        mqttVersion: 4,
+        // If mqttVersionExplicit is true, it will force the connection to use the selected MQTT Version or will fail to connect.
+        // If mqttVersionExplicit is false and mqttVersion is 4, it will try mqttVersion: 4 and if it fails it will fallback to mqttVersion: 3
+        // Here's the relevant code: https://github.com/eclipse/paho.mqtt.javascript/blob/f5859463aba9a9b7c19f99ab7c4849a723f8d832/src/paho-mqtt.js#L1610
+        mqttVersionExplicit: false,
         reconnect: true,
         onSuccess: onConnect,
         onFailure: onFailure


### PR DESCRIPTION
PR #747 introduced mqttVersion but this causes issue with brokers that enforce a minimum spec (v3.1.1).

This PR enforces the original default logic, specifying both mqttVersion and mqttVersionExplicit, with this configuration, the client tries first with 4 and if it fails fallsback to 3, so it should work with all brokers that support either v3.1 or v3.1.1.

You can check the relevant code that implements that connect logic in the paho client js code:
https://github.com/eclipse/paho.mqtt.javascript/blob/f5859463aba9a9b7c19f99ab7c4849a723f8d832/src/paho-mqtt.js#L1610