### PR TITLE
Fix for tooltip rounding on weatherRange

### DIFF
--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -2719,6 +2719,8 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
                     # Add rounding from weewx.conf/skin.conf so Highcharts can use it
                     if observation_type == "rainTotal":
                         rounding_obs_lookup = "rain"
+                    elif observation_type == "weatherRange":
+                        rounding_obs_lookup = weatherRange_obs_lookup
                     else:
                         rounding_obs_lookup = observation_type
                     try:

--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -2786,6 +2786,7 @@ function showChart(json_file, prepend_renderTo = false) {
                 var currentSeries = options.series;
                 var currentSeriesData = options.series[0].data;
                 var range_unit = options.series[0].range_unit;
+                var rounding = options.series[0].rounding;
                 var newSeriesData = [];
                 currentSeriesData.forEach(seriesData => {
                     if (options.series[0].color) {
@@ -2806,7 +2807,8 @@ function showChart(json_file, prepend_renderTo = false) {
                 options.series.push({
                     data: newSeriesData,
                     obsType: "weatherRange",
-                    obsUnit: range_unit
+                    obsUnit: range_unit,
+                    rounding: rounding
                 });
             }
 


### PR DESCRIPTION
This is a fix for the weatherRange graph so it correctly looks up the rounding for observation being and uses that rather than the default of -1.0 in the json data.   This means it falls back to the default of two decimal places.

The js script has to also be updated so it is being included in the highchart data.

Before the fix;
![image](https://user-images.githubusercontent.com/59254774/172258363-6533efd0-ad95-4392-a84e-b2abc2be995b.png)


With the fix;
![image](https://user-images.githubusercontent.com/59254774/172257722-5e2f904a-d22b-4b3b-89b7-c70d6f0e1dc0.png)

James