### PR TITLE
Fix for tooltip rounding on haysChart

### DIFF
--- a/bin/user/belchertown.py
+++ b/bin/user/belchertown.py
@@ -2721,6 +2721,8 @@ class HighchartsJsonGenerator(weewx.reportengine.ReportGenerator):
                         rounding_obs_lookup = "rain"
                     elif observation_type == "weatherRange":
                         rounding_obs_lookup = weatherRange_obs_lookup
+                    elif observation_type == "haysChart":
+                        rounding_obs_lookup = "windSpeed"
                     else:
                         rounding_obs_lookup = observation_type
                     try:

--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -2641,6 +2641,7 @@ function showChart(json_file, prepend_renderTo = false) {
                 var currentSeries = options.series;
                 var currentSeriesData = options.series[0].data;
                 var range_unit = options.series[0].range_unit;
+                var rounding = options.series[0].rounding;
                 var newSeriesData = [];
                 var currentSeriesColor = options.series[0].color;
                 currentSeriesData.forEach(seriesData => {
@@ -2655,6 +2656,7 @@ function showChart(json_file, prepend_renderTo = false) {
                     data: newSeriesData,
                     obsType: "haysChart",
                     obsUnit: range_unit,
+                    rounding: rounding,
                     color: currentSeriesColor,
                     fillColor: currentSeriesColor,
                     connectEnds: false,


### PR DESCRIPTION
This is applying the same logic as #788, but for haysChart.

Before - 
 
![image](https://user-images.githubusercontent.com/59254774/172263384-67d5c956-d500-4e23-89b3-2ecc084ce411.png)

After - 

![image](https://user-images.githubusercontent.com/59254774/172263400-4b05674d-2101-4b7c-8612-4291b0de3f37.png)

Noting I'm using knots so it is correctly going to 0 decimal places.
