### PR TITLE
Allow use of windDir ordinals when using wind vector

### DIFF
--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -2392,7 +2392,7 @@ function showChart(json_file, prepend_renderTo = false) {
                     options.yAxis[this_yAxis].minorGridLineWidth = 1;
                 }
 
-                if (s.obsType == "windDir") {
+                if (s.obsType == "windDir" || s.obsType == "wind") {
                     options.yAxis[this_yAxis].tickInterval = 90;
                     options.yAxis[this_yAxis].labels = {
                         useHTML: true,


### PR DESCRIPTION
This change is to support issue #824 

In Summary;
Support the use of wind rather than windDir when user wanting to graph a vector of wind direction when using an aggregate_interval which is not the same as your archive period (eg 300 seconds when archive is 60 seconds)

This will cause the y-axis to display N, E, S, W, and N.

User must be weewx 4.9.1 if aggregate interval is less than one day.