### PR TITLE
Pin HighCharts CDN ref to 10.x.x

### DIFF
--- a/skins/Belchertown/header.html.tmpl
+++ b/skins/Belchertown/header.html.tmpl
@@ -108,10 +108,10 @@
         <script type='text/javascript' src="//cdnjs.cloudflare.com/ajax/libs/paho-mqtt/1.1.0/paho-mqtt.min.js"></script>
         #end if
         #if $page != "kiosk"
-        <script type='text/javascript' src='//code.highcharts.com/stock/highstock.js'></script>
-        <script type='text/javascript' src='//code.highcharts.com/highcharts-more.js'></script>
-        <script type='text/javascript' src='//code.highcharts.com/modules/exporting.js'></script>
-        <script type='text/javascript' src='//code.highcharts.com/modules/solid-gauge.js'></script>
+        <script type='text/javascript' src='//code.highcharts.com/stock/10/highstock.js'></script>
+        <script type='text/javascript' src='//code.highcharts.com/10/highcharts-more.js'></script>
+        <script type='text/javascript' src='//code.highcharts.com/10/modules/exporting.js'></script>
+        <script type='text/javascript' src='//code.highcharts.com/10/modules/solid-gauge.js'></script>
         #end if
         <script type='text/javascript' src='//stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js'></script>
         <script type='text/javascript' src='$relative_url/js/belchertown.js?#echo int( time.time() )#'></script>


### PR DESCRIPTION
* Per [instructions from code.highcharts.com](https://code.highcharts.com/#:~:text=highcharts%2Dmore.js-,TRUNCATED%20VERSIONS,-By%20truncating%20the) on using the CDN for pinned & truncated versions.
* Addresses #881 