### PR TITLE
Add missing "drizzle" icon to install

### DIFF
--- a/install.py
+++ b/install.py
@@ -217,6 +217,7 @@ files=[('bin/user', ['bin/user/belchertown.py'
        ('skins/Belchertown/images', ['skins/Belchertown/images/clear-day.png',
                                      'skins/Belchertown/images/clear-night.png',
                                      'skins/Belchertown/images/cloudy.png',
+                                     'skins/Belchertown/images/drizzle.png',
                                      'skins/Belchertown/images/fog.png',
                                      'skins/Belchertown/images/hail.png',
                                      'skins/Belchertown/images/mostly-clear-day.png',


### PR DESCRIPTION
This morning, which was looking drizzly, I noticed my weather station displaying a broken image icon for the day's weather prediction.
Checking, I saw it pointing to `drizzle.png` which was a 404.
Tracking things through, I saw the image was indeed in the repo, but not in my installed image.
The solution was clear - the icon was missing from `install.py`
Fixed