### PR TITLE
Update belchertown.js.tmpl - new_radar_image

### DIFF
--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -1542,7 +1542,8 @@ function ajaximages(section = false, reload_timer_interval_seconds = false) {
     // Reload images
         if (document.querySelectorAll(".radar-map img").length > 0) {
             var radar_img = document.querySelectorAll(".radar-map img")[0].src;
-            var new_radar_img = radar_img + "&t=" + Math.floor(Math.random() * 999999999);
+            //var new_radar_img = radar_img + "&t=" + Math.floor(Math.random() * 999999999);
+            var new_radar_img = radar_img;
             document.querySelectorAll(".radar-map img")[0].src = new_radar_img;
             //var radar_html = jQuery('.radar-map').children('img').attr('src').split('?')[0] // Get the img src and remove everything after "?" so we don't stack ?'s onto the image during updates
             //jQuery('.radar-map').children('img').attr('src', radar_html + "?" + Math.floor(Math.random() * 999999999));


### PR DESCRIPTION
When using Aeris API, the radar API does not like the added variables. 

This pull request revokes the `&t=123456789` variable from being appended. 

In some instances, the `&t=12345679` would become duplicated and show something like `&t=12345679&t=12345679&t=12345679`.

In any method of the above, when the &t=numeric is appended, Aeris API responds with the following error:

```json
{
  "error": {
    "code": "request_url_error",
    "message": "Invalid url: /RedactedKey/flat-dk,water-depth-dk,counties:60,rivers,interstates:60,admin-cities-dk,alerts-severe:50:blend(lighten),radar:blend(lighten)/650x360/38.80,-94.78,8/20240820110300_20240820110300.png&t=12345679"
  }
}
```