### PR TITLE
Fix for a potential octal literal error when hour/minute has leading 0

### DIFF
--- a/skins/Belchertown/js/belchertown.js.tmpl
+++ b/skins/Belchertown/js/belchertown.js.tmpl
@@ -73,7 +73,7 @@ jQuery(document).ready(function() {
             belchertown_debug("Theme: Setting auto theme because of URL override");
             sessionStorage.setItem('theme', 'auto')
             #if $almanac.sunrise.raw is not None and $almanac.sunset.raw is not None
-            autoTheme(#echo datetime.datetime.fromtimestamp($almanac.sunset.raw).strftime('%H')#, #echo datetime.datetime.fromtimestamp($almanac.sunset.raw).strftime('%M')#, #echo datetime.datetime.fromtimestamp($almanac.sunrise.raw).strftime('%H')#, #echo datetime.datetime.fromtimestamp($almanac.sunrise.raw).strftime('%M')#)
+            autoTheme(#echo datetime.datetime.fromtimestamp($almanac.sunset.raw).strftime('%-H')#, #echo datetime.datetime.fromtimestamp($almanac.sunset.raw).strftime('%-M')#, #echo datetime.datetime.fromtimestamp($almanac.sunrise.raw).strftime('%-H')#, #echo datetime.datetime.fromtimestamp($almanac.sunrise.raw).strftime('%-M')#)
             #end if
         }
     }


### PR DESCRIPTION
Makes sure date/time variables are returned without leading zeroes to avoid an octal literal error in JS. 